### PR TITLE
fix: 画像エクスポートを安定化しE2E回帰テストを導入

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,35 @@
+name: E2E
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  playwright:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browser
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: pnpm test:e2e

--- a/components/deckBuilder.tsx
+++ b/components/deckBuilder.tsx
@@ -48,6 +48,7 @@ export default function DeckBuilder({ urlDeckCode }: DeckBuilderProps) {
     handleAwakeningSelect,
     handleImport,
     handleExport,
+    handleScreenshotError,
     handleShare,
     handleClear,
     handleOpenSaveModal,
@@ -105,6 +106,7 @@ export default function DeckBuilder({ urlDeckCode }: DeckBuilderProps) {
         onLoad={handleOpenLoadModal}
         onSortCharacters={handleSortCharacters}
         contentRef={contentRef}
+        onScreenshotError={handleScreenshotError}
       />
 
       <div className="container mx-auto px-0 sm:px-3 md:px-4 pt-40 md:pt-28 pb-8">

--- a/components/photo-mode-container.tsx
+++ b/components/photo-mode-container.tsx
@@ -19,7 +19,7 @@ export function PhotoModeContainer({ isPhotoMode, children }: PhotoModeContainer
       className={`transition-all duration-300 ${isPhotoMode ? "photo-mode bg-black py-4 px-2" : ""}`}
     >
       {children}
-      <ScreenshotButton targetRef={containerRef} isPhotoMode={isPhotoMode} />
+      <ScreenshotButton targetRef={containerRef} />
     </div>
   )
 }

--- a/components/screenshot-button.tsx
+++ b/components/screenshot-button.tsx
@@ -10,14 +10,25 @@ import { useTranslations } from "next-intl"
 
 interface ScreenshotButtonProps {
   targetRef: React.RefObject<HTMLDivElement | null>
+  onCaptureError?: (error: Error) => void
 }
 
-export function ScreenshotButton({ targetRef }: ScreenshotButtonProps) {
+const TRANSPARENT_PIXEL_DATA_URL =
+  "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=="
+
+export function ScreenshotButton({ targetRef, onCaptureError }: ScreenshotButtonProps) {
   const [isCapturing, setIsCapturing] = useState(false)
   const t = useTranslations()
 
   const captureScreenshot = async () => {
-    if (!targetRef.current) return
+    if (!targetRef.current) {
+      const missingTargetError = new Error("Screenshot capture target not found.")
+      onCaptureError?.(missingTargetError)
+      console.error(missingTargetError.message)
+      return
+    }
+
+    const captureTarget = targetRef.current
 
     try {
       if (analytics && typeof window !== "undefined") {
@@ -26,17 +37,21 @@ export function ScreenshotButton({ targetRef }: ScreenshotButtonProps) {
       setIsCapturing(true)
 
       // 캡처 모드 클래스 추가 - 테두리 효과 제거를 위한 클래스
-      if (targetRef.current) {
-        targetRef.current.classList.add("capture-mode")
-      }
+      captureTarget.classList.add("capture-mode")
 
       // DOM이 업데이트될 시간을 주기 위해 약간 지연
       await new Promise((resolve) => setTimeout(resolve, 300))
 
       // 스크린샷 캡처
-      const dataUrl = await htmlToImage.toPng(targetRef.current, {
+      const dataUrl = await htmlToImage.toPng(captureTarget, {
         quality: 1,
         pixelRatio: window.devicePixelRatio || 1,
+        cacheBust: true,
+        imagePlaceholder: TRANSPARENT_PIXEL_DATA_URL,
+        fetchRequestInit: {
+          mode: "cors",
+          credentials: "omit",
+        },
       })
 
       // 다운로드 링크 생성 및 클릭
@@ -46,11 +61,10 @@ export function ScreenshotButton({ targetRef }: ScreenshotButtonProps) {
       link.click()
     } catch (error) {
       console.error("Screenshot capture failed:", error)
+      onCaptureError?.(error instanceof Error ? error : new Error("Unknown screenshot capture error."))
     } finally {
       // 캡처 모드 클래스 제거
-      if (targetRef.current) {
-        targetRef.current.classList.remove("capture-mode")
-      }
+      captureTarget.classList.remove("capture-mode")
       setIsCapturing(false)
     }
   }
@@ -60,7 +74,7 @@ export function ScreenshotButton({ targetRef }: ScreenshotButtonProps) {
       <button
         onClick={captureScreenshot}
         disabled={isCapturing}
-        className={`neon-button flex items-center justify-center w-8 h-8 sm:w-10 sm:h-10 rounded-lg transition-colors duration-200 shadow-md relative overflow-hidden
+        className={`screenshot-button neon-button flex items-center justify-center w-8 h-8 sm:w-10 sm:h-10 rounded-lg transition-colors duration-200 shadow-md relative overflow-hidden
         ${isCapturing ? "opacity-50 cursor-not-allowed" : ""}
       `}
         title={t("capture_screenshot") || "Capture Screenshot"}

--- a/components/top-bar.tsx
+++ b/components/top-bar.tsx
@@ -22,6 +22,7 @@ interface TopBarProps {
   onLoad: () => void // 추가: 불러오기 버튼 핸들러
   onSortCharacters?: () => void
   contentRef: React.RefObject<HTMLDivElement | null> // 추가: 캡처할 컨텐츠 참조
+  onScreenshotError?: (error: Error) => void
 }
 
 export function TopBar({
@@ -33,6 +34,7 @@ export function TopBar({
   onLoad,
   onSortCharacters,
   contentRef,
+  onScreenshotError,
 }: TopBarProps) {
   const helpPopupRef = useRef<HTMLDivElement>(null)
   const languageButtonRef = useRef<HTMLButtonElement>(null)
@@ -128,7 +130,7 @@ export function TopBar({
               </div>
 
               {/* Screenshot Button - 캡처 버튼으로 변경 */}
-              <ScreenshotButton targetRef={contentRef} />
+              <ScreenshotButton targetRef={contentRef} onCaptureError={onScreenshotError} />
 
               {/* Share Button */}
               <button

--- a/hooks/deck-builder/useDeckBuilderPage.tsx
+++ b/hooks/deck-builder/useDeckBuilderPage.tsx
@@ -287,6 +287,14 @@ export function useDeckBuilderPage(urlDeckCode: string | null) {
     }
   }, [exportPreset, showToast, selectedCharacters, locale, t])
 
+  const handleScreenshotError = useCallback(
+    (error: Error) => {
+      console.error("Screenshot capture error:", error)
+      showToast(t("screenshot_failed"), "error")
+    },
+    [showToast, t],
+  )
+
   const handleShare = useCallback(() => {
     try {
       const result = createShareableUrl()
@@ -495,6 +503,7 @@ export function useDeckBuilderPage(urlDeckCode: string | null) {
     showLoadModal,
     handleImport,
     handleExport,
+    handleScreenshotError,
     handleShare,
     handleClear,
     handleOpenSaveModal,

--- a/messages/cn.json
+++ b/messages/cn.json
@@ -86,6 +86,7 @@
   "edit": "编辑",
   "export_success": "导出成功！",
   "export_failed": "导出失败！",
+  "screenshot_failed": "截图导出失败。",
   "import_success": "导入成功！",
   "import_failed": "导入失败！",
   "clear_success": "所有设置已清除！",

--- a/messages/en.json
+++ b/messages/en.json
@@ -107,6 +107,7 @@
   "edit": "Edit",
   "export_success": "Export successful!",
   "export_failed": "Export failed!",
+  "screenshot_failed": "Screenshot capture failed.",
   "import_success": "Import successful!",
   "import_failed": "Import failed!",
   "clear_success": "All settings cleared!",

--- a/messages/jp.json
+++ b/messages/jp.json
@@ -140,6 +140,7 @@
   "edit": "編集",
   "export_success": "エクスポート成功！",
   "export_failed": "エクスポート失敗！",
+  "screenshot_failed": "スクリーンショットの作成に失敗しました。",
   "import_success": "インポート成功！",
   "import_failed": "インポート失敗！",
   "clear_success": "すべての設定をクリアしました！",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -85,6 +85,7 @@
   "edit": "편집",
   "export_success": "내보내기에 성공했습니다!",
   "export_failed": "내보내기에 실패했습니다!",
+  "screenshot_failed": "스크린샷 캡처에 실패했습니다.",
   "import_success": "가져오기에 성공했습니다!",
   "import_failed": "가져오기에 실패했습니다!",
   "clear_success": "모든 설정이 초기화되었습니다!",

--- a/messages/tw.json
+++ b/messages/tw.json
@@ -85,6 +85,7 @@
   "edit": "編輯",
   "export_success": "匯出成功！",
   "export_failed": "匯出失敗！",
+  "screenshot_failed": "螢幕截圖匯出失敗。",
   "import_success": "匯入成功！",
   "import_failed": "匯入失敗！",
   "clear_success": "所有設定已清除！",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "test": "vitest",
     "coverage": "vitest run --coverage",
-    "test:ui": "vitest --ui"
+    "test:ui": "vitest --ui",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@dnd-kit/core": "latest",
@@ -70,6 +71,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4.1.18",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from "@playwright/test"
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  timeout: 60_000,
+  fullyParallel: false,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "list",
+  use: {
+    baseURL: "http://127.0.0.1:3000",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "pnpm dev --hostname 127.0.0.1 --port 3000",
+    url: "http://127.0.0.1:3000/jp",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: {
+      NEXT_PUBLIC_FIREBASE_API_KEY: "e2e-api-key",
+      NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: "e2e.firebaseapp.com",
+      NEXT_PUBLIC_FIREBASE_PROJECT_ID: "e2e-project",
+      NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: "e2e.appspot.com",
+      NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: "1234567890",
+      NEXT_PUBLIC_FIREBASE_APP_ID: "1:1234567890:web:e2e",
+      NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID: "G-E2E0000000",
+      NEXT_PUBLIC_FIREBASE_ANALYTICS_ENABLED: "false",
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,10 +134,10 @@ importers:
         version: 0.563.0(react@19.2.4)
       next:
         specifier: 16.1.6
-        version: 16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.1.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-intl:
         specifier: ^4.8.2
-        version: 4.8.2(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+        version: 4.8.2(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -181,6 +181,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@tailwindcss/postcss':
         specifier: ^4.1.18
         version: 4.1.18
@@ -1037,6 +1040,11 @@ packages:
   '@parcel/watcher@2.5.6':
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -2395,6 +2403,11 @@ packages:
   firebase@12.9.0:
     resolution: {integrity: sha512-CwwTYoqZg6KxygPOaaJqIc4aoLvo0RCRrXoln9GoxLE8QyAwTydBaSLGVlR4WPcuOgN3OEL0tJLT1H4IU/dv7w==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2690,6 +2703,16 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   po-parser@2.1.1:
     resolution: {integrity: sha512-ECF4zHLbUItpUgE3OTtLKlPjeBN+fKEczj2zYjDfCGOzicNs0GK3Vg2IoAYwx7LH/XYw43fZQP6xnZ4TkNxSLQ==}
@@ -3900,6 +3923,10 @@ snapshots:
       '@parcel/watcher-win32-arm64': 2.5.6
       '@parcel/watcher-win32-ia32': 2.5.6
       '@parcel/watcher-win32-x64': 2.5.6
+
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -5231,6 +5258,9 @@ snapshots:
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -5436,14 +5466,14 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.8.2: {}
 
-  next-intl@4.8.2(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
+  next-intl@4.8.2(next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.5.10
       '@parcel/watcher': 2.5.6
       '@swc/core': 1.15.11
       icu-minify: 4.8.2
       negotiator: 1.0.0
-      next: 16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.1.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-intl-swc-plugin-extractor: 4.8.2
       po-parser: 2.1.1
       react: 19.2.4
@@ -5458,7 +5488,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.1.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
@@ -5477,6 +5507,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.1.6
       '@next/swc-win32-arm64-msvc': 16.1.6
       '@next/swc-win32-x64-msvc': 16.1.6
+      '@playwright/test': 1.59.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -5497,6 +5528,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.3: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   po-parser@2.1.1: {}
 

--- a/tests/e2e/screenshot-export.spec.ts
+++ b/tests/e2e/screenshot-export.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "@playwright/test"
+
+const TINY_PNG_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO6M5x8AAAAASUVORK5CYII="
+
+test("exports deck screenshot as a downloadable PNG", async ({ page }) => {
+  await page.route("https://patchwiki.biligame.com/images/resonance/**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "image/png",
+      headers: {
+        "access-control-allow-origin": "*",
+        "cache-control": "no-store",
+      },
+      body: Buffer.from(TINY_PNG_BASE64, "base64"),
+    })
+  })
+
+  await page.goto("/jp")
+  await expect(page.locator(".capture-content")).toBeVisible()
+
+  const downloadPromise = page.waitForEvent("download")
+  await page.locator("button.screenshot-button").click()
+  const download = await downloadPromise
+
+  expect(download.suggestedFilename()).toMatch(/^deck-builder-screenshot-.*\.png$/)
+})

--- a/tests/unit/components/screenshot-button.test.tsx
+++ b/tests/unit/components/screenshot-button.test.tsx
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 import React from "react"
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { ScreenshotButton } from "@/components/screenshot-button"
 
@@ -24,6 +24,12 @@ vi.mock("html-to-image", () => ({
 }))
 
 describe("ScreenshotButton", () => {
+  beforeEach(() => {
+    screenshotMocks.logEventWrapper.mockClear()
+    screenshotMocks.toPngMock.mockReset()
+    screenshotMocks.toPngMock.mockResolvedValue("data-url")
+  })
+
   it("captures screenshot and toggles capture mode", async () => {
     vi.useFakeTimers()
 
@@ -42,7 +48,14 @@ describe("ScreenshotButton", () => {
       await Promise.resolve()
     })
 
-    expect(screenshotMocks.toPngMock).toHaveBeenCalled()
+    expect(screenshotMocks.toPngMock).toHaveBeenCalledWith(
+      target,
+      expect.objectContaining({
+        cacheBust: true,
+        imagePlaceholder: expect.stringContaining("data:image/gif;base64"),
+        fetchRequestInit: { mode: "cors", credentials: "omit" },
+      }),
+    )
     expect(target.classList.contains("capture-mode")).toBe(false)
 
     expect(screenshotMocks.logEventWrapper).toHaveBeenCalled()
@@ -50,5 +63,36 @@ describe("ScreenshotButton", () => {
 
     clickSpy.mockRestore()
     vi.useRealTimers()
+  })
+
+  it("calls onCaptureError when capture fails", async () => {
+    vi.useFakeTimers()
+    const onCaptureError = vi.fn()
+    const target = document.createElement("div")
+    const targetRef = { current: target }
+    screenshotMocks.toPngMock.mockRejectedValueOnce(new Error("capture failure"))
+
+    render(<ScreenshotButton targetRef={targetRef} onCaptureError={onCaptureError} />)
+    fireEvent.click(screen.getByRole("button"))
+
+    await act(async () => {
+      await vi.runAllTimersAsync()
+      await Promise.resolve()
+    })
+
+    expect(onCaptureError).toHaveBeenCalledWith(expect.any(Error))
+    expect(target.classList.contains("capture-mode")).toBe(false)
+    vi.useRealTimers()
+  })
+
+  it("calls onCaptureError when target is missing", () => {
+    const onCaptureError = vi.fn()
+    const targetRef = { current: null }
+
+    render(<ScreenshotButton targetRef={targetRef} onCaptureError={onCaptureError} />)
+    fireEvent.click(screen.getByRole("button"))
+
+    expect(onCaptureError).toHaveBeenCalledWith(expect.any(Error))
+    expect(screenshotMocks.toPngMock).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## 概要
- 画像エクスポート（スクリーンショット）処理を安定化し、失敗時のUI通知を追加
- Playwright E2E を導入し、画像エクスポート回帰をPRごとに自動検知
- #45 の不具合対応と継続検証基盤の整備

## 変更内容
1. 画像エクスポートの改善
- `components/screenshot-button.tsx`
  - `cacheBust` / `imagePlaceholder` / `fetchRequestInit` を追加
  - 失敗時に `onCaptureError` を返せるように拡張
  - CSSセレクタ用 `screenshot-button` クラスを追加
- `hooks/deck-builder/useDeckBuilderPage.tsx`
  - `handleScreenshotError` を追加し、トースト通知へ接続
- `components/top-bar.tsx` / `components/deckBuilder.tsx`
  - スクリーンショットエラーのハンドリングを受け渡し
- `components/photo-mode-container.tsx`
  - `ScreenshotButton` への不正な props 渡しを修正

2. 多言語メッセージ追加
- `messages/{en,jp,ko,cn,tw}.json`
  - `screenshot_failed` を追加

3. E2E 導入と CI 連携
- `playwright.config.ts` を追加
- `tests/e2e/screenshot-export.spec.ts` を追加
  - スクリーンショットボタン押下で PNG ダウンロードが発生することを検証
- `.github/workflows/e2e.yml` を追加
  - PR時に Playwright E2E を実行
- `package.json` に `test:e2e` スクリプトを追加

4. ユニットテスト更新
- `tests/unit/components/screenshot-button.test.tsx`
  - 追加オプション検証
  - 失敗時コールバック経路検証

## 動作確認
- `pnpm build`
- `pnpm exec vitest run`
- `pnpm test:e2e`

## 補足
- `pnpm lint` は既存の Next.js lint コマンド設定問題（`next lint` 実行時のディレクトリ解釈）により失敗する状態のため、本PRでは対象外。

Closes #45
