### PR TITLE
fix: ルビーの共鳴と覚醒の並び順を修正

### DIFF
--- a/lib/charDb.ts
+++ b/lib/charDb.ts
@@ -8878,6 +8878,9 @@ export const characters: Record<string, Character> =
     ],
     "breakthroughList": [
       {
+        "breakthroughId": 12101406
+      },
+      {
         "breakthroughId": 12101401
       },
       {
@@ -8891,9 +8894,6 @@ export const characters: Record<string, Character> =
       },
       {
         "breakthroughId": 12101405
-      },
-      {
-        "breakthroughId": 12101406
       }
     ],
     "line": 1,


### PR DESCRIPTION
## 概要
- ルビー（`10001314`）の共鳴/覚醒表示順が崩れる問題を修正

## 変更内容
- `lib/charDb.ts` のルビー `breakthroughList` を並び替え
  - 先頭に生活スキル `12101406`
  - 続いて覚醒1〜5 `12101401`〜`12101405`

## 影響
- 既存UIロジック（`breakthroughList.slice(1)`）で、覚醒が正しい順序で表示されるようになる

Closes #48
