### PR TITLE
ci: PlayWright公式DockerイメージをE2E CIで使用する

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,9 @@ jobs:
   playwright:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    container:
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
+      options: --ipc=host
 
     steps:
       - name: Checkout code
@@ -19,17 +22,8 @@ jobs:
         with:
           version: latest
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24.x
-          cache: pnpm
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Install Playwright browser
-        run: pnpm exec playwright install --with-deps chromium
 
       - name: Run E2E tests
         run: pnpm test:e2e


### PR DESCRIPTION
## 背景

CIのE2Eジョブで `playwright install --with-deps chromium` がタイムアウトし、テストが実行できない問題がありました。

## 変更内容

`.github/workflows/e2e.yml` のジョブに公式 Playwright Docker イメージ (`mcr.microsoft.com/playwright:v1.59.1-noble`) を使用するよう変更しました。このイメージには Chromium が事前インストールされているため、ブラウザのインストール手順が不要になります。

- `container: mcr.microsoft.com/playwright:v1.59.1-noble` を追加
- `options: --ipc=host` を追加 (Chromium が共有メモリを使用するために必要)
- `Install Playwright browser` ステップを削除 (タイムアウトの原因)
- `actions/setup-node@v4` を削除 (Docker イメージに Node.js が含まれるため不要)

Fixes: #63