### PR TITLE
test: limit Vitest worker count for stable coverage runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "lint": "next lint",
     "test": "vitest",
-    "coverage": "vitest run --coverage",
+    "coverage": "vitest run --coverage --maxWorkers=5",
     "test:ui": "vitest --ui",
     "test:e2e": "playwright test"
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,8 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
+    maxWorkers: 5,
+    minWorkers: 1,
     include: ['lib/**/*.test.ts', 'tests/**/*.test.ts', 'tests/**/*.test.tsx'],
     exclude: ['node_modules', 'tests/**/*.spec.ts'],
     setupFiles: [path.resolve(__dirname, 'tests/setup.ts')],


### PR DESCRIPTION
Coverage実行時の並列数が環境依存で増えすぎると、実行負荷が上がって不安定になりやすいため、ワーカー数を明示的に制限しました。

## 変更内容
- `vitest.config.ts` の `test` 設定に `maxWorkers: 5` と `minWorkers: 1` を追加
- `package.json` の `coverage` スクリプトを `vitest run --coverage --maxWorkers=5` に更新

## 補足
- 通常の `pnpm test` とカバレッジ実行の両方で、過剰並列を避ける設定に揃えています。