### PR TITLE
feat: lazy-load CommentsSection and split Firebase runtime modules

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -7,7 +7,7 @@ import { LoadingScreen } from "../../components/loading-screen"
 import { useDataLoader } from "../../hooks/use-data-loader"
 
 // Firebase Analytics 관련 import 수정
-import { logEventWrapper } from "../../lib/firebase-config"
+import { logEventWrapper } from "../../lib/firebase-analytics"
 
 export default function Page({ params }) {
   const { locale } = use(params);

--- a/components/comments-section.tsx
+++ b/components/comments-section.tsx
@@ -19,7 +19,7 @@ import {
   type QueryDocumentSnapshot,
   type DocumentData,
 } from "firebase/firestore"
-import { db } from "../lib/firebase-config"
+import { db } from "../lib/firebase-firestore"
 import { useTranslations, useLocale } from "next-intl"
 
 interface Comment {

--- a/components/deckBuilder.tsx
+++ b/components/deckBuilder.tsx
@@ -1,15 +1,20 @@
 "use client"
 
+import dynamic from "next/dynamic"
 import { TopBar } from "./top-bar"
 import { CharacterWindow } from "./character-window"
 import { SkillWindow } from "./skill-window"
 import { BattleSettings } from "./battle-settings"
-import { CommentsSection } from "./comments-section"
 import { LoadingScreen } from "./loading-screen"
 import { SaveDeckModal } from "./ui/modal/SaveDeckModal"
 import { LoadDeckModal } from "./ui/modal/LoadDeckModal"
 import { useDeckBuilderPage } from "../hooks/deck-builder/useDeckBuilderPage"
 import { useTranslations, useLocale } from "next-intl"
+
+const CommentsSection = dynamic(
+  () => import("./comments-section").then((m) => ({ default: m.CommentsSection })),
+  { loading: () => null, ssr: false },
+)
 
 interface DeckBuilderProps {
   urlDeckCode: string | null

--- a/components/screenshot-button.tsx
+++ b/components/screenshot-button.tsx
@@ -5,7 +5,7 @@ import type React from "react"
 import { useState } from "react"
 import { Camera } from "lucide-react"
 import * as htmlToImage from "html-to-image"
-import { analytics, logEventWrapper } from "../lib/firebase-config"
+import { analytics, logEventWrapper } from "../lib/firebase-analytics"
 import { useTranslations } from "next-intl"
 
 interface ScreenshotButtonProps {

--- a/hooks/deck-builder/useCommentsSection.ts
+++ b/hooks/deck-builder/useCommentsSection.ts
@@ -15,7 +15,7 @@ import {
   type QueryDocumentSnapshot,
   type DocumentData,
 } from "firebase/firestore"
-import { db } from "@/lib/firebase-config"
+import { db } from "@/lib/firebase-firestore"
 
 interface Comment {
   id: string

--- a/hooks/deck-builder/useDeckBuilderPage.tsx
+++ b/hooks/deck-builder/useDeckBuilderPage.tsx
@@ -5,7 +5,7 @@ import { useLocale, useTranslations } from "next-intl"
 import { processSkillDescription } from "@/utils/skill-description"
 
 import { useDeckBuilder } from "."
-import { logEventWrapper } from "../../lib/firebase-config"
+import { logEventWrapper } from "../../lib/firebase-analytics"
 import { decodePresetFromUrlParam } from "../../utils/presetCodec"
 import { getCurrentDeckId, removeCurrentDeckId, setCurrentDeckId, type SavedDeck } from "../../utils/local-storage"
 import type { CardExtraInfo, Database } from "../../types"

--- a/lib/firebase-analytics.ts
+++ b/lib/firebase-analytics.ts
@@ -1,0 +1,25 @@
+import { getAnalytics, logEvent } from "firebase/analytics"
+import { app } from "./firebase-app"
+
+export const analytics = typeof window !== "undefined" ? getAnalytics(app) : null
+
+const isProd = process.env.NODE_ENV === "production"
+const isAnalyticsEnabled = process.env.NEXT_PUBLIC_FIREBASE_ANALYTICS_ENABLED === "true"
+
+export const logEventWrapper = (eventName: string, eventParams?: Record<string, unknown>) => {
+  if (!isProd || !isAnalyticsEnabled) {
+    console.log(`[DEV] Firebase Analytics Events: ${eventName}`, eventParams)
+    return
+  }
+
+  if (typeof window !== "undefined" && analytics) {
+    try {
+      logEvent(analytics, eventName, eventParams)
+    } catch (error) {
+      console.error(`[ERROR] Failed to log event: ${eventName}`, error)
+    }
+  } else {
+    console.warn(`[WARN] Analytics not available. Event: ${eventName}`, eventParams)
+    console.log(`[DEBUG] isProd: ${isProd}, isAnalyticsEnabled: ${isAnalyticsEnabled}`)
+  }
+}

--- a/lib/firebase-app.ts
+++ b/lib/firebase-app.ts
@@ -1,0 +1,13 @@
+import { initializeApp } from "firebase/app"
+
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+  measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
+}
+
+export const app = initializeApp(firebaseConfig)

--- a/lib/firebase-config.ts
+++ b/lib/firebase-config.ts
@@ -1,42 +1,6 @@
-import { initializeApp } from "firebase/app"
-import { getFirestore } from "firebase/firestore"
-import { getAnalytics, logEvent } from "firebase/analytics"
-
-const firebaseConfig = {
-  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
-  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
-  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
-  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
-  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
-  measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
-};
-
-const app = initializeApp(firebaseConfig)
-
-export const db = getFirestore(app)
-
-// Initialize Firebase Analytics
-export const analytics = typeof window !== "undefined" ? getAnalytics(app) : null
-
-const isProd = process.env.NODE_ENV === "production"
-const isAnalyticsEnabled = process.env.NEXT_PUBLIC_FIREBASE_ANALYTICS_ENABLED === "true"
-
-// 새로운 래핑된 logEvent 함수로 대체
-export const logEventWrapper = (eventName: string, eventParams?: Record<string, any>) => {
-  if (!isProd || !isAnalyticsEnabled) {
-    console.log(`[DEV] Firebase Analytics Events: ${eventName}`, eventParams)
-    return
-  }
-
-  if (typeof window !== "undefined" && analytics) {
-    try {
-      logEvent(analytics, eventName, eventParams)
-    } catch (error) {
-      console.error(`[ERROR] Failed to log event: ${eventName}`, error)
-    }
-  } else {
-    console.warn(`[WARN] Analytics not available. Event: ${eventName}`, eventParams)
-    console.log(`[DEBUG] isProd: ${isProd}, isAnalyticsEnabled: ${isAnalyticsEnabled}`)
-  }
-}
+// 後方互換性のための re-export バレル
+// 新規コードは各モジュールを直接インポートしてください:
+//   import { db } from "@/lib/firebase-firestore"
+//   import { analytics, logEventWrapper } from "@/lib/firebase-analytics"
+export { db } from "./firebase-firestore"
+export { analytics, logEventWrapper } from "./firebase-analytics"

--- a/lib/firebase-firestore.ts
+++ b/lib/firebase-firestore.ts
@@ -1,0 +1,4 @@
+import { getFirestore } from "firebase/firestore"
+import { app } from "./firebase-app"
+
+export const db = getFirestore(app)

--- a/tests/unit/components/screenshot-button.test.tsx
+++ b/tests/unit/components/screenshot-button.test.tsx
@@ -14,7 +14,7 @@ vi.mock("next-intl", () => ({
   useTranslations: () => (key: string) => key,
 }))
 
-vi.mock("@/lib/firebase-config", () => ({
+vi.mock("@/lib/firebase-analytics", () => ({
   analytics: {},
   logEventWrapper: screenshotMocks.logEventWrapper,
 }))

--- a/tests/unit/hooks/useCommentsSection.test.ts
+++ b/tests/unit/hooks/useCommentsSection.test.ts
@@ -1,0 +1,275 @@
+/** @vitest-environment jsdom */
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+// Firebase Firestore をモック
+const mockGetDocs = vi.fn()
+const mockAddDoc = vi.fn()
+const mockUpdateDoc = vi.fn()
+const mockDeleteDoc = vi.fn()
+const mockCollection = vi.fn()
+const mockDoc = vi.fn()
+const mockQuery = vi.fn()
+const mockOrderBy = vi.fn()
+const mockLimit = vi.fn()
+const mockStartAfter = vi.fn()
+const mockServerTimestamp = vi.fn(() => ({ toDate: () => new Date() }))
+
+vi.mock("firebase/firestore", () => ({
+  addDoc: mockAddDoc,
+  collection: mockCollection,
+  serverTimestamp: mockServerTimestamp,
+  query: mockQuery,
+  orderBy: mockOrderBy,
+  doc: mockDoc,
+  deleteDoc: mockDeleteDoc,
+  updateDoc: mockUpdateDoc,
+  limit: mockLimit,
+  startAfter: mockStartAfter,
+  getDocs: mockGetDocs,
+}))
+
+vi.mock("@/lib/firebase-firestore", () => ({
+  db: {},
+}))
+
+// uuid モック
+vi.mock("uuid", () => ({
+  v4: vi.fn(() => "test-uuid-1234"),
+}))
+
+// next-intl モック
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+  useLocale: () => "en",
+}))
+
+// useCommentsSection を動的インポートするためのヘルパー
+async function importHook() {
+  const { useCommentsSection } = await import("@/hooks/deck-builder/useCommentsSection")
+  return useCommentsSection
+}
+
+function makeSnapshot(docs: Array<{ id: string; data: Record<string, unknown> }>) {
+  const snapDocs = docs.map((d) => ({
+    id: d.id,
+    data: () => d.data,
+  }))
+  return {
+    empty: docs.length === 0,
+    docs: snapDocs,
+  }
+}
+
+describe("useCommentsSection", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    localStorage.clear()
+
+    mockCollection.mockReturnValue("collection-ref")
+    mockDoc.mockReturnValue("doc-ref")
+    mockQuery.mockReturnValue("query-ref")
+    mockOrderBy.mockReturnValue("orderby-ref")
+    mockLimit.mockReturnValue("limit-ref")
+    mockStartAfter.mockReturnValue("startafter-ref")
+    mockAddDoc.mockResolvedValue({ id: "new-comment-id" })
+    mockUpdateDoc.mockResolvedValue(undefined)
+    mockDeleteDoc.mockResolvedValue(undefined)
+    mockGetDocs.mockResolvedValue(makeSnapshot([]))
+  })
+
+  describe("初期化", () => {
+    it("localStorage に userId がない場合、新しい UUID を生成して保存する", async () => {
+      const useCommentsSection = await importHook()
+      const { result } = renderHook(() => useCommentsSection({ currentLanguage: "en" }))
+
+      await waitFor(() => {
+        expect(result.current.userId).toBe("test-uuid-1234")
+      })
+      expect(localStorage.getItem("anonymousUserId")).toBe("test-uuid-1234")
+    })
+
+    it("localStorage に userId がある場合、それを使う", async () => {
+      localStorage.setItem("anonymousUserId", "existing-user-id")
+      const useCommentsSection = await importHook()
+      const { result } = renderHook(() => useCommentsSection({ currentLanguage: "en" }))
+
+      await waitFor(() => {
+        expect(result.current.userId).toBe("existing-user-id")
+      })
+    })
+
+    it("初期状態でコメントリストが空である", async () => {
+      const useCommentsSection = await importHook()
+      const { result } = renderHook(() => useCommentsSection({ currentLanguage: "en" }))
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false)
+      })
+      expect(result.current.comments).toHaveLength(0)
+    })
+  })
+
+  describe("コメント読み込み", () => {
+    it("初期ロードでコメントを取得する", async () => {
+      const createdAt = { toDate: () => new Date("2025-01-01") }
+      mockGetDocs.mockResolvedValueOnce(
+        makeSnapshot([
+          { id: "c1", data: { content: "Hello", userId: "user-1", createdAt } },
+          { id: "c2", data: { content: "World", userId: "user-2", createdAt } },
+        ]),
+      )
+
+      const useCommentsSection = await importHook()
+      const { result } = renderHook(() => useCommentsSection({ currentLanguage: "en" }))
+
+      await waitFor(() => {
+        expect(result.current.comments).toHaveLength(2)
+      })
+      expect(result.current.comments[0].content).toBe("Hello")
+      expect(result.current.comments[1].content).toBe("World")
+    })
+
+    it("コメントが5件未満の場合、hasMore が false になる", async () => {
+      mockGetDocs.mockResolvedValueOnce(makeSnapshot([{ id: "c1", data: { content: "Hi", userId: "u1", createdAt: { toDate: () => new Date() } } }]))
+
+      const useCommentsSection = await importHook()
+      const { result } = renderHook(() => useCommentsSection({ currentLanguage: "en" }))
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false)
+      })
+      expect(result.current.hasMore).toBe(false)
+    })
+  })
+
+  describe("コメント追加", () => {
+    it("新しいコメントを追加するとローカル状態に反映される", async () => {
+      mockGetDocs.mockResolvedValue(makeSnapshot([]))
+
+      const useCommentsSection = await importHook()
+      const { result } = renderHook(() => useCommentsSection({ currentLanguage: "en" }))
+
+      await waitFor(() => expect(result.current.loading).toBe(false))
+
+      act(() => {
+        result.current.setNewComment("新しいコメント")
+      })
+
+      await act(async () => {
+        await result.current.addComment()
+      })
+
+      expect(mockAddDoc).toHaveBeenCalledWith(
+        "collection-ref",
+        expect.objectContaining({ content: "新しいコメント" }),
+      )
+      expect(result.current.comments[0].content).toBe("新しいコメント")
+      expect(result.current.newComment).toBe("")
+    })
+
+    it("空のコメントは送信しない", async () => {
+      const useCommentsSection = await importHook()
+      const { result } = renderHook(() => useCommentsSection({ currentLanguage: "en" }))
+
+      await waitFor(() => expect(result.current.loading).toBe(false))
+
+      await act(async () => {
+        await result.current.addComment()
+      })
+
+      expect(mockAddDoc).not.toHaveBeenCalled()
+    })
+
+    it("コメント送信後にクールダウンが設定される", async () => {
+      mockGetDocs.mockResolvedValue(makeSnapshot([]))
+
+      const useCommentsSection = await importHook()
+      const { result } = renderHook(() => useCommentsSection({ currentLanguage: "en" }))
+
+      await waitFor(() => expect(result.current.loading).toBe(false))
+
+      act(() => result.current.setNewComment("テスト"))
+      await act(async () => { await result.current.addComment() })
+
+      expect(result.current.canComment).toBe(false)
+      expect(localStorage.getItem("lastCommentTime")).not.toBeNull()
+    })
+  })
+
+  describe("コメント削除", () => {
+    it("コメントを削除するとリストから取り除かれる", async () => {
+      const createdAt = { toDate: () => new Date() }
+      mockGetDocs.mockResolvedValueOnce(
+        makeSnapshot([{ id: "c1", data: { content: "削除対象", userId: "u1", createdAt } }]),
+      )
+
+      const useCommentsSection = await importHook()
+      const { result } = renderHook(() => useCommentsSection({ currentLanguage: "en" }))
+
+      await waitFor(() => expect(result.current.comments).toHaveLength(1))
+
+      await act(async () => {
+        await result.current.deleteComment("c1")
+      })
+
+      expect(mockDeleteDoc).toHaveBeenCalled()
+      expect(result.current.comments).toHaveLength(0)
+    })
+  })
+
+  describe("コメント編集", () => {
+    it("startEditing でコメントの編集モードに入る", async () => {
+      const useCommentsSection = await importHook()
+      const { result } = renderHook(() => useCommentsSection({ currentLanguage: "en" }))
+
+      await waitFor(() => expect(result.current.loading).toBe(false))
+
+      const comment = { id: "c1", content: "元のテキスト", userId: "u1", date: new Date().toISOString() }
+
+      act(() => {
+        result.current.startEditing(comment)
+      })
+
+      expect(result.current.editingCommentId).toBe("c1")
+      expect(result.current.editContent).toBe("元のテキスト")
+    })
+
+    it("cancelEditing で編集モードを終了する", async () => {
+      const useCommentsSection = await importHook()
+      const { result } = renderHook(() => useCommentsSection({ currentLanguage: "en" }))
+
+      const comment = { id: "c1", content: "テキスト", userId: "u1", date: new Date().toISOString() }
+      act(() => result.current.startEditing(comment))
+      act(() => result.current.cancelEditing())
+
+      expect(result.current.editingCommentId).toBeNull()
+      expect(result.current.editContent).toBe("")
+    })
+
+    it("編集中に addComment を呼ぶとコメントが更新される", async () => {
+      const createdAt = { toDate: () => new Date() }
+      mockGetDocs.mockResolvedValueOnce(
+        makeSnapshot([{ id: "c1", data: { content: "旧テキスト", userId: "u1", createdAt } }]),
+      )
+
+      const useCommentsSection = await importHook()
+      const { result } = renderHook(() => useCommentsSection({ currentLanguage: "en" }))
+
+      await waitFor(() => expect(result.current.comments).toHaveLength(1))
+
+      act(() => result.current.startEditing(result.current.comments[0]))
+      act(() => result.current.setEditContent("新テキスト"))
+
+      await act(async () => { await result.current.addComment() })
+
+      expect(mockUpdateDoc).toHaveBeenCalledWith(
+        "doc-ref",
+        expect.objectContaining({ content: "新テキスト" }),
+      )
+      expect(result.current.comments[0].content).toBe("新テキスト")
+      expect(result.current.editingCommentId).toBeNull()
+    })
+  })
+})

--- a/tests/unit/lib/firebase-analytics.test.ts
+++ b/tests/unit/lib/firebase-analytics.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+// firebase/analytics をモック
+const mockLogEvent = vi.fn()
+const mockGetAnalytics = vi.fn(() => ({ name: "mock-analytics" }))
+
+vi.mock("firebase/app", () => ({
+  initializeApp: vi.fn(() => ({ name: "mock-app" })),
+}))
+
+vi.mock("firebase/analytics", () => ({
+  getAnalytics: mockGetAnalytics,
+  logEvent: mockLogEvent,
+}))
+
+vi.mock("@/lib/firebase-app", () => ({
+  app: { name: "mock-app" },
+}))
+
+describe("firebase-analytics", () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    vi.resetModules()
+    process.env = { ...originalEnv }
+    mockLogEvent.mockClear()
+    mockGetAnalytics.mockClear()
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  describe("logEventWrapper - development mode", () => {
+    it("コンソールにログを出力し、analytics.logEvent を呼ばない", async () => {
+      process.env.NODE_ENV = "development"
+      process.env.NEXT_PUBLIC_FIREBASE_ANALYTICS_ENABLED = "false"
+
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {})
+
+      const { logEventWrapper } = await import("@/lib/firebase-analytics")
+      logEventWrapper("test_event", { key: "value" })
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[DEV] Firebase Analytics Events: test_event"),
+        { key: "value" },
+      )
+      expect(mockLogEvent).not.toHaveBeenCalled()
+
+      consoleSpy.mockRestore()
+    })
+
+    it("イベントパラメータなしでも動作する", async () => {
+      process.env.NODE_ENV = "development"
+      process.env.NEXT_PUBLIC_FIREBASE_ANALYTICS_ENABLED = "false"
+
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {})
+
+      const { logEventWrapper } = await import("@/lib/firebase-analytics")
+      logEventWrapper("page_view")
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[DEV] Firebase Analytics Events: page_view"),
+        undefined,
+      )
+
+      consoleSpy.mockRestore()
+    })
+  })
+
+  describe("logEventWrapper - production mode (analytics disabled)", () => {
+    it("NEXT_PUBLIC_FIREBASE_ANALYTICS_ENABLED=false のとき logEvent を呼ばない", async () => {
+      process.env.NODE_ENV = "production"
+      process.env.NEXT_PUBLIC_FIREBASE_ANALYTICS_ENABLED = "false"
+
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {})
+
+      const { logEventWrapper } = await import("@/lib/firebase-analytics")
+      logEventWrapper("test_event")
+
+      expect(mockLogEvent).not.toHaveBeenCalled()
+
+      consoleSpy.mockRestore()
+    })
+  })
+
+  describe("logEventWrapper - production mode (analytics enabled)", () => {
+    it("window が存在し analytics が有効なとき logEvent を呼ぶ", async () => {
+      process.env.NODE_ENV = "production"
+      process.env.NEXT_PUBLIC_FIREBASE_ANALYTICS_ENABLED = "true"
+
+      // analytics インスタンスをモジュール内で参照させるため、モックを設定
+      const fakeAnalytics = { name: "analytics" }
+      mockGetAnalytics.mockReturnValue(fakeAnalytics)
+
+      const { logEventWrapper } = await import("@/lib/firebase-analytics")
+      logEventWrapper("test_event", { param: "val" })
+
+      // window が jsdom 環境で存在するため、logEvent が呼ばれるか確認
+      // analytics が null でない場合のみ呼ばれる
+      expect(mockLogEvent).toHaveBeenCalledWith(
+        expect.anything(),
+        "test_event",
+        { param: "val" },
+      )
+    })
+
+    it("logEvent が例外を投げても握りつぶしてエラーログを出す", async () => {
+      process.env.NODE_ENV = "production"
+      process.env.NEXT_PUBLIC_FIREBASE_ANALYTICS_ENABLED = "true"
+
+      mockLogEvent.mockImplementationOnce(() => {
+        throw new Error("analytics error")
+      })
+
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+      const { logEventWrapper } = await import("@/lib/firebase-analytics")
+      expect(() => logEventWrapper("fail_event")).not.toThrow()
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[ERROR] Failed to log event: fail_event"),
+        expect.any(Error),
+      )
+
+      errorSpy.mockRestore()
+    })
+  })
+})


### PR DESCRIPTION
## 概要 / Summary

初期JSバンドルに `firebase/firestore` が含まれることで、ページ初回ロード時の転送量が増加していました。このPRでは Firebase config を責務ごとに分割し、`CommentsSection` コンポーネントを `next/dynamic` で遅延ロードすることで初期バンドルサイズを削減します。

## 変更内容

### Firebase モジュール分割

従来の単一ファイル `lib/firebase-config.ts` を3つの責務別モジュールに分割:

- `lib/firebase-app.ts` - Firebase app 初期化のみ
- `lib/firebase-firestore.ts` - Firestore (`db`) のみをエクスポート
- `lib/firebase-analytics.ts` - Analytics + `logEventWrapper` をエクスポート（dev/prod 分岐含む）

`lib/firebase-config.ts` は re-export バレルとして残し、後方互換性を維持しています。

### CommentsSection の遅延ロード

`components/deckBuilder.tsx` で `CommentsSection` を `next/dynamic({ ssr: false })` でインポートするよう変更しました。これにより `firebase/firestore` が初期バンドルから除外され、コメントセクションの表示が必要になったときのみ動的にロードされます。

## テスト（TDD）

テストファーストで実装:

- `tests/unit/lib/firebase-analytics.test.ts` (新規): `logEventWrapper` の dev/prod 分岐・エラーハンドリング（5テスト）
- `tests/unit/hooks/useCommentsSection.test.ts` (新規): コメント CRUD・クールダウン処理（12テスト）
- 既存テスト含む全 28ファイル / 93テスト パス

Fixes: #60