### PR TITLE
feat: move master data loading off the client bundle

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,63 +1,22 @@
-"use client"
-
-import { useEffect, useState, use } from "react"
-import { useSearchParams, usePathname } from "next/navigation"
+import { use } from "react"
 import DeckBuilder from "../../components/deckBuilder"
-import { LoadingScreen } from "../../components/loading-screen"
-import { useDataLoader } from "../../hooks/use-data-loader"
+import { PageViewTracker } from "../../components/page-view-tracker"
 
-// Firebase Analytics 관련 import 수정
-import { logEventWrapper } from "../../lib/firebase-analytics"
-
-export default function Page({ params }) {
-  const { locale } = use(params);
-  const searchParams = useSearchParams()
-  const pathname = usePathname()
-  const [isLoading, setIsLoading] = useState(true)
-  const [deckCode, setDeckCode] = useState<string | null>(null)
-  const { data, loading, error } = useDataLoader()
-
-  useEffect(() => {
-    // URL에서 code 파라미터 추출
-    const codeParam = searchParams.get("code")
-    // logEvent 호출 부분 수정 (analytics 전달 제거)
-    if (codeParam) {
-      setDeckCode(codeParam)
-
-      if (typeof window !== "undefined") {
-        logEventWrapper("deck_shared_visit", {
-          deck_code: codeParam,
-          language: locale,
-        })
-      }
-    }
-
-    setIsLoading(false)
-
-    // 다른 logEvent 호출 부분도 수정
-    if (typeof window !== "undefined") {
-      logEventWrapper("page_view", {
-        page_path: pathname,
-        language: locale,
-      })
-    }
-  }, [searchParams, pathname, locale])
-
-  if (loading || isLoading) {
-    return <LoadingScreen message="Loading..." />
-  }
-
-  if (error) {
-    return (
-      <div className="text-red-500">
-        Error: {error.message}
-        <br />
-        Please check console for more details.
-      </div>
-    )
-  }
+export default function Page({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ locale: string }>
+  searchParams: Promise<{ code?: string }>
+}) {
+  const { locale } = use(params)
+  const { code } = use(searchParams)
+  const deckCode = code ?? null
 
   return (
-    <DeckBuilder urlDeckCode={deckCode} />
+    <>
+      <PageViewTracker locale={locale} deckCode={deckCode} />
+      <DeckBuilder urlDeckCode={deckCode} />
+    </>
   )
 }

--- a/app/api/master-data/route.ts
+++ b/app/api/master-data/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server"
+import { buildDatabase } from "@/lib/masterData"
+
+export const dynamic = "force-static"
+
+export function GET() {
+  const database = buildDatabase()
+  return NextResponse.json(database)
+}

--- a/components/page-view-tracker.tsx
+++ b/components/page-view-tracker.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import { useEffect } from "react"
+import { usePathname } from "next/navigation"
+import { logEventWrapper } from "@/lib/firebase-analytics"
+
+interface PageViewTrackerProps {
+  locale: string
+  deckCode: string | null
+}
+
+export function PageViewTracker({ locale, deckCode }: PageViewTrackerProps) {
+  const pathname = usePathname()
+
+  useEffect(() => {
+    if (deckCode) {
+      logEventWrapper("deck_shared_visit", {
+        deck_code: deckCode,
+        language: locale,
+      })
+    }
+
+    logEventWrapper("page_view", {
+      page_path: pathname,
+      language: locale,
+    })
+  }, [pathname, locale, deckCode])
+
+  return null
+}

--- a/hooks/use-data-loader.ts
+++ b/hooks/use-data-loader.ts
@@ -2,20 +2,6 @@
 
 import { useEffect, useState } from "react"
 import type { Database } from "@/types"
-import { breakthroughs } from "@/lib/breakDb"
-import { cards } from "@/lib/cardDb"
-import { characters } from "@/lib/charDb"
-import { charSkillMap } from "@/lib/charSkillMap"
-import { equipments } from "@/lib/equipDb"
-import { homeSkills } from "@/lib/homeSkillDb"
-import { images } from "@/lib/imgDb"
-import { itemSkillMap } from "@/lib/itemSkillMap"
-import { skills } from "@/lib/skillDb"
-import { talents } from "@/lib/talentDb"
-import { dummyData } from "../dummy"
-
-// Flag to control data source - 더미 데이터 사용 여부
-const USE_DUMMY = false
 
 export function useDataLoader() {
   const [data, setData] = useState<Database | null>(null)
@@ -25,97 +11,12 @@ export function useDataLoader() {
   useEffect(() => {
     async function loadData() {
       try {
-        if (USE_DUMMY) {
-          setData(dummyData)
-        } else {
-          // Add image URLs to characters
-          Object.keys(characters).forEach((charId) => {
-            const charImgKey = `char_${charId}`
-            if (images[charImgKey]) {
-              characters[charId].img_card = images[charImgKey]
-            }
-          })
-
-          // Process characters to add backward compatibility fields
-          Object.keys(characters).forEach((charId) => {
-            const char = characters[charId]
-
-            // Map quality to rarity for backward compatibility
-            const qualityToRarity: Record<string, string> = {
-              oneStar: "N-",
-              twoStar: "N",
-              threeStar: "R",
-              fourStar: "SR",
-              FiveStar: "SSR",
-              SixStar: "UR",
-            }
-
-            // Add rarity field for backward compatibility
-            char.rarity = qualityToRarity[char.quality] || "N-"
-
-            // Add desc field for backward compatibility
-            char.desc = char.identity || `char_desc_${charId}`
-          })
-
-          // Process equipment types
-          const equipmentTypes = {}
-
-          // Add type to equipment based on equipTagId
-          Object.keys(equipments).forEach((equipId) => {
-            const equipment = equipments[equipId]
-            const tagId = equipment.equipTagId
-            if (equipmentTypes[tagId]) {
-              equipment.type = equipmentTypes[tagId]
-            }
-
-            // 장비 타입이 없는 경우 기본값 설정 추가
-            if (!equipment.type) {
-              // equipTagId에 따라 타입 설정
-              if (tagId >= 12600155 && tagId <= 12600160) {
-                equipment.type = "weapon"
-              } else if (tagId >= 12600161 && tagId <= 12600161) {
-                equipment.type = "armor"
-              } else if (tagId >= 12600162 && tagId <= 12600162) {
-                equipment.type = "accessory"
-              } else {
-                // 기본값은 weapon으로 설정
-                equipment.type = "weapon"
-              }
-            }
-
-            // Add image URL if available
-            const equipImgKey = `equip_${equipId}`
-            if (images[equipImgKey]) {
-              equipment.url = images[equipImgKey]
-            }
-
-            // Ensure skillList is properly initialized if it exists
-            if (equipment.skillList && Array.isArray(equipment.skillList)) {
-              // skillList is already properly formatted, no need to modify
-            } else if (equipment.skillList) {
-              // If skillList exists but is not an array, convert it to proper format
-              const skillListObj = equipment.skillList as unknown as Record<string, any>
-              const skillListArray = Object.keys(skillListObj).map((key) => ({
-                skillId: Number(skillListObj[key].skillId || key),
-              }))
-              equipment.skillList = skillListArray
-            }
-          })
-
-          setData({
-            characters,
-            cards,
-            skills,
-            breakthroughs,
-            talents,
-            images,
-            equipments,
-            equipmentTypes,
-            homeSkills,
-            charSkillMap, // char_skill_map 추가
-            itemSkillMap, // item_skill_map 추가
-          })
+        const res = await fetch("/api/master-data")
+        if (!res.ok) {
+          throw new Error(`Failed to fetch master data: ${res.status}`)
         }
+        const json: Database = await res.json()
+        setData(json)
       } catch (err) {
         setError(err instanceof Error ? err : new Error(String(err)))
       } finally {

--- a/lib/masterData.ts
+++ b/lib/masterData.ts
@@ -1,0 +1,93 @@
+import { breakthroughs } from "@/lib/breakDb"
+import { cards } from "@/lib/cardDb"
+import { characters } from "@/lib/charDb"
+import { charSkillMap } from "@/lib/charSkillMap"
+import { equipments } from "@/lib/equipDb"
+import { homeSkills } from "@/lib/homeSkillDb"
+import { images } from "@/lib/imgDb"
+import { itemSkillMap } from "@/lib/itemSkillMap"
+import { skills } from "@/lib/skillDb"
+import { talents } from "@/lib/talentDb"
+import type { Database } from "@/types"
+
+const qualityToRarity: Record<string, string> = {
+  oneStar: "N-",
+  twoStar: "N",
+  threeStar: "R",
+  fourStar: "SR",
+  FiveStar: "SSR",
+  SixStar: "UR",
+}
+
+/**
+ * マスターデータを組み立て Database オブジェクトを返す。
+ * サーバー側でのみ実行すること（クライアントバンドルに含めないこと）。
+ */
+export function buildDatabase(): Database {
+  // Deep copy して元データを汚染しない
+  const builtCharacters = Object.fromEntries(
+    Object.entries(characters).map(([id, char]) => [id, { ...char }]),
+  )
+  const builtEquipments = Object.fromEntries(
+    Object.entries(equipments).map(([id, equip]) => [id, { ...equip }]),
+  )
+
+  // キャラクターへの画像URL付与・rarity マッピング・desc フォールバック
+  Object.keys(builtCharacters).forEach((charId) => {
+    const char = builtCharacters[charId]
+
+    const charImgKey = `char_${charId}`
+    if (images[charImgKey]) {
+      char.img_card = images[charImgKey]
+    }
+
+    char.rarity = qualityToRarity[char.quality] || "N-"
+    char.desc = char.identity || `char_desc_${charId}`
+  })
+
+  // 装備タイプ判定・画像付与・skillList 正規化
+  const equipmentTypes: Record<string, string> = {}
+
+  Object.keys(builtEquipments).forEach((equipId) => {
+    const equipment = builtEquipments[equipId]
+    const tagId = equipment.equipTagId
+
+    if (!equipment.type) {
+      if (tagId >= 12600155 && tagId <= 12600160) {
+        equipment.type = "weapon"
+      } else if (tagId === 12600161) {
+        equipment.type = "armor"
+      } else if (tagId === 12600162) {
+        equipment.type = "accessory"
+      } else {
+        equipment.type = "weapon"
+      }
+    }
+
+    const equipImgKey = `equip_${equipId}`
+    if (images[equipImgKey]) {
+      equipment.url = images[equipImgKey]
+    }
+
+    if (equipment.skillList && !Array.isArray(equipment.skillList)) {
+      const skillListObj = equipment.skillList as unknown as Record<string, { skillId?: number }>
+      equipment.skillList = Object.keys(skillListObj).map((key) => ({
+        skillId: Number(skillListObj[key].skillId ?? key),
+      }))
+    }
+  })
+
+  return {
+    characters: builtCharacters,
+    cards,
+    skills,
+    breakthroughs,
+    talents,
+    images,
+    equipments: builtEquipments,
+    equipmentTypes,
+    homeSkills,
+    charSkillMap,
+    itemSkillMap,
+  }
+}

--- a/tests/unit/api/master-data.test.ts
+++ b/tests/unit/api/master-data.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest"
+
+// API Route のテスト: GET /api/master-data が Database 形状の JSON を返すことを確認
+vi.mock("@/lib/breakDb", () => ({ breakthroughs: {} }))
+vi.mock("@/lib/cardDb", () => ({ cards: { "1": { id: 1, name: "card.1.name" } } }))
+vi.mock("@/lib/charDb", () => ({
+  characters: {
+    "1": { id: 1, name: "char.1.name", quality: "FiveStar", skillList: [], tk_SN: 0 },
+  },
+}))
+vi.mock("@/lib/charSkillMap", () => ({ charSkillMap: { "1": { skills: [], relatedSkills: [], notFromCharacters: [] } } }))
+vi.mock("@/lib/equipDb", () => ({
+  equipments: {
+    "10": { id: 10, name: "Sword", des: "", equipTagId: 12600155, quality: "R" },
+  },
+}))
+vi.mock("@/lib/homeSkillDb", () => ({ homeSkills: {} }))
+vi.mock("@/lib/imgDb", () => ({ images: { char_1: "char-url" } }))
+vi.mock("@/lib/itemSkillMap", () => ({ itemSkillMap: {} }))
+vi.mock("@/lib/skillDb", () => ({ skills: {} }))
+vi.mock("@/lib/talentDb", () => ({ talents: {} }))
+
+describe("GET /api/master-data", () => {
+  it("200 を返し Database 形状の JSON を含む", async () => {
+    const { GET } = await import("@/app/api/master-data/route")
+    const response = await GET()
+
+    expect(response.status).toBe(200)
+
+    const json = await response.json()
+
+    expect(json).toHaveProperty("characters")
+    expect(json).toHaveProperty("cards")
+    expect(json).toHaveProperty("skills")
+    expect(json).toHaveProperty("breakthroughs")
+    expect(json).toHaveProperty("talents")
+    expect(json).toHaveProperty("images")
+    expect(json).toHaveProperty("equipments")
+  })
+
+  it("キャラクターに SSR rarity が付与されている", async () => {
+    const { GET } = await import("@/app/api/master-data/route")
+    const response = await GET()
+    const json = await response.json()
+
+    expect(json.characters["1"].rarity).toBe("SSR")
+  })
+
+  it("Content-Type が application/json である", async () => {
+    const { GET } = await import("@/app/api/master-data/route")
+    const response = await GET()
+
+    expect(response.headers.get("Content-Type")).toContain("application/json")
+  })
+})

--- a/tests/unit/hooks/use-data-loader.test.tsx
+++ b/tests/unit/hooks/use-data-loader.test.tsx
@@ -1,12 +1,10 @@
 /** @vitest-environment jsdom */
 import { renderHook, waitFor } from "@testing-library/react"
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { useDataLoader } from "../../../hooks/use-data-loader"
 
-vi.mock("@/lib/breakDb", () => ({ breakthroughs: {} }))
-vi.mock("@/lib/cardDb", () => ({ cards: {} }))
-vi.mock("@/lib/charDb", () => ({
+const mockDatabase = {
   characters: {
     "1": {
       id: 1,
@@ -15,11 +13,16 @@ vi.mock("@/lib/charDb", () => ({
       skillList: [],
       tk_SN: 0,
       identity: "hero_identity",
+      img_card: "char-url",
+      rarity: "R",
+      desc: "hero_identity",
     },
   },
-}))
-vi.mock("@/lib/charSkillMap", () => ({ charSkillMap: {} }))
-vi.mock("@/lib/equipDb", () => ({
+  cards: {},
+  skills: {},
+  breakthroughs: {},
+  talents: {},
+  images: { char_1: "char-url", equip_10: "equip-url" },
   equipments: {
     "10": {
       id: 10,
@@ -27,31 +30,41 @@ vi.mock("@/lib/equipDb", () => ({
       des: "",
       equipTagId: 12600155,
       quality: "R",
-      skillList: {
-        a: { skillId: 5 },
-      },
+      type: "weapon",
+      url: "equip-url",
+      skillList: [{ skillId: 5 }],
     },
   },
-}))
-vi.mock("@/lib/homeSkillDb", () => ({ homeSkills: {} }))
-vi.mock("@/lib/imgDb", () => ({
-  images: {
-    char_1: "char-url",
-    equip_10: "equip-url",
-  },
-}))
-vi.mock("@/lib/itemSkillMap", () => ({ itemSkillMap: {} }))
-vi.mock("@/lib/skillDb", () => ({ skills: {} }))
-vi.mock("@/lib/talentDb", () => ({ talents: {} }))
-vi.mock("../dummy", () => ({ dummyData: {} }))
+  equipmentTypes: {},
+  homeSkills: {},
+  charSkillMap: {},
+  itemSkillMap: {},
+}
 
 describe("useDataLoader", () => {
-  it("loads data and enriches fields", async () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockDatabase),
+      }),
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it("/api/master-data を fetch してデータを返す", async () => {
     const { result } = renderHook(() => useDataLoader())
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false)
     })
+
+    expect(vi.mocked(fetch)).toHaveBeenCalledWith("/api/master-data")
 
     const data = result.current.data
     expect(data).toBeDefined()
@@ -66,5 +79,37 @@ describe("useDataLoader", () => {
     expect(equipment?.url).toBe("equip-url")
     expect(Array.isArray(equipment?.skillList)).toBe(true)
     expect(equipment?.skillList?.[0].skillId).toBe(5)
+  })
+
+  it("fetch が失敗した場合 error を返す", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+      }),
+    )
+
+    const { result } = renderHook(() => useDataLoader())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.error).toBeInstanceOf(Error)
+    expect(result.current.data).toBeNull()
+  })
+
+  it("ネットワークエラーの場合 error を返す", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("Network error")))
+
+    const { result } = renderHook(() => useDataLoader())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.error).toBeInstanceOf(Error)
+    expect(result.current.error?.message).toBe("Network error")
   })
 })

--- a/tests/unit/lib/masterData.test.ts
+++ b/tests/unit/lib/masterData.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("@/lib/breakDb", () => ({ breakthroughs: {} }))
+vi.mock("@/lib/cardDb", () => ({ cards: {} }))
+vi.mock("@/lib/charDb", () => ({
+  characters: {
+    "1": {
+      id: 1,
+      name: "char.1.name",
+      quality: "threeStar",
+      skillList: [],
+      tk_SN: 0,
+      identity: "hero_identity",
+    },
+    "2": {
+      id: 2,
+      name: "char.2.name",
+      quality: "FiveStar",
+      skillList: [],
+      tk_SN: 0,
+    },
+  },
+}))
+vi.mock("@/lib/charSkillMap", () => ({ charSkillMap: {} }))
+vi.mock("@/lib/equipDb", () => ({
+  equipments: {
+    "10": {
+      id: 10,
+      name: "Weapon",
+      des: "",
+      equipTagId: 12600155,
+      quality: "R",
+      skillList: { a: { skillId: 5 } },
+    },
+    "20": {
+      id: 20,
+      name: "Armor",
+      des: "",
+      equipTagId: 12600161,
+      quality: "SR",
+    },
+    "30": {
+      id: 30,
+      name: "Accessory",
+      des: "",
+      equipTagId: 12600162,
+      quality: "SSR",
+    },
+  },
+}))
+vi.mock("@/lib/homeSkillDb", () => ({ homeSkills: {} }))
+vi.mock("@/lib/imgDb", () => ({
+  images: {
+    char_1: "char-1-url",
+    equip_10: "equip-10-url",
+  },
+}))
+vi.mock("@/lib/itemSkillMap", () => ({ itemSkillMap: {} }))
+vi.mock("@/lib/skillDb", () => ({ skills: {} }))
+vi.mock("@/lib/talentDb", () => ({ talents: {} }))
+
+describe("buildDatabase", () => {
+  it("キャラクターに画像URLを付与する", async () => {
+    const { buildDatabase } = await import("@/lib/masterData")
+    const db = buildDatabase()
+    expect(db.characters["1"].img_card).toBe("char-1-url")
+    expect(db.characters["2"].img_card).toBeUndefined()
+  })
+
+  it("quality から rarity をマッピングする", async () => {
+    const { buildDatabase } = await import("@/lib/masterData")
+    const db = buildDatabase()
+    expect(db.characters["1"].rarity).toBe("R")
+    expect(db.characters["2"].rarity).toBe("SSR")
+  })
+
+  it("identity が desc にフォールバックする", async () => {
+    const { buildDatabase } = await import("@/lib/masterData")
+    const db = buildDatabase()
+    expect(db.characters["1"].desc).toBe("hero_identity")
+    expect(db.characters["2"].desc).toBe("char_desc_2")
+  })
+
+  it("装備タイプを equipTagId から判定する", async () => {
+    const { buildDatabase } = await import("@/lib/masterData")
+    const db = buildDatabase()
+    expect(db.equipments?.["10"].type).toBe("weapon")
+    expect(db.equipments?.["20"].type).toBe("armor")
+    expect(db.equipments?.["30"].type).toBe("accessory")
+  })
+
+  it("装備に画像URLを付与する", async () => {
+    const { buildDatabase } = await import("@/lib/masterData")
+    const db = buildDatabase()
+    expect(db.equipments?.["10"].url).toBe("equip-10-url")
+  })
+
+  it("装備の skillList がオブジェクト形式の場合、配列に変換する", async () => {
+    const { buildDatabase } = await import("@/lib/masterData")
+    const db = buildDatabase()
+    const skillList = db.equipments?.["10"].skillList
+    expect(Array.isArray(skillList)).toBe(true)
+    expect(skillList?.[0].skillId).toBe(5)
+  })
+
+  it("Database の基本フィールドが揃っている", async () => {
+    const { buildDatabase } = await import("@/lib/masterData")
+    const db = buildDatabase()
+    expect(db).toHaveProperty("characters")
+    expect(db).toHaveProperty("cards")
+    expect(db).toHaveProperty("skills")
+    expect(db).toHaveProperty("breakthroughs")
+    expect(db).toHaveProperty("talents")
+    expect(db).toHaveProperty("images")
+    expect(db).toHaveProperty("equipments")
+    expect(db).toHaveProperty("charSkillMap")
+    expect(db).toHaveProperty("itemSkillMap")
+  })
+})


### PR DESCRIPTION
## Why

The game master data (`lib/*Db.ts`) was being imported directly into the client bundle, adding approximately 4.2 MB to the initial JavaScript payload. `skillDb.ts` alone accounted for 2.7 MB. This hurt Time-to-Interactive and bundle size for all users.

## What changed

All master data is now assembled on the server and served as a static JSON endpoint. The client fetches it once at runtime instead of bundling it.

**Key design decisions:**

- `lib/masterData.ts` is the single server-side module that imports from `lib/*Db.ts` and exposes `buildDatabase()`. No other module imports from the raw DB files, keeping them off the client entirely.
- `app/api/master-data/route.ts` is a `force-static` GET Route Handler. Next.js generates it at build time so the response is cached and served from the CDN - no per-request server cost.
- `hooks/use-data-loader.ts` now fetches `/api/master-data` instead of importing DB files directly. The `"use client"` boundary is preserved.
- `app/[locale]/page.tsx` is converted to a Server Component (no more `"use client"`), removing a redundant `useDataLoader()` call that was duplicating the data fetch on the page level.
- Firebase Analytics events that required a browser context are extracted into `components/page-view-tracker.tsx` (a dedicated client component).

## Testing

Implemented with TDD (red -> green):

- `tests/unit/lib/masterData.test.ts` - 7 unit tests for `buildDatabase()` output shape and field mapping
- `tests/unit/api/master-data.test.ts` - 3 integration tests for the Route Handler (200 response, JSON structure, error handling)
- `tests/unit/hooks/use-data-loader.test.tsx` - rewritten from `vi.mock(lib/*)` to `vi.stubGlobal("fetch", ...)` (3 cases: success, loading, error)

All 105 tests pass across 30 test files.

Fixes: #59