### PR TITLE
fix: カルのスキル1【羽休み】のコストを3から2に修正

### DIFF
--- a/lib/cardDb.ts
+++ b/lib/cardDb.ts
@@ -14205,7 +14205,7 @@ export const cards: Record<string, Card> =
       "idCN": "00原版/05五星/嘉尔/A",
       "name": "card.10600518.name",
       "color": "Purple",
-      "cost_SN": 30000,
+      "cost_SN": 20000,
       "cardType": "Normal",
       "ExCondList": [],
       "ExActList": [

--- a/tests/unit/lib/issue-75-karu-skill1-cost.test.ts
+++ b/tests/unit/lib/issue-75-karu-skill1-cost.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest"
+
+// Issue #75: カルのスキル1【羽休み】のコストを3→2に修正
+// カードID: 10600518, スキルID: 12303991
+// cost_SN は実際のコスト * 10000 で格納される（例: 30000 = コスト3, 20000 = コスト2）
+
+describe("Issue #75: カルのスキル1【羽休み】コスト修正", () => {
+  it("【羽休み】(カードID: 10600518) のコストが2である", async () => {
+    const { cards } = await import("@/lib/cardDb")
+    const card = cards["10600518"]
+
+    expect(card).toBeDefined()
+    expect(card.id).toBe(10600518)
+    expect(card.cost_SN).toBe(20000) // コスト2 = 20000 (2 * 10000)
+  })
+})


### PR DESCRIPTION
## 変更の背景

ゲームアップデートにより、カル（キャラクターID: 10001089）のスキル1【羽休み】のコストが3から2に変更されました。この変更をデータベースに反映します。

## 変更内容

`lib/cardDb.ts` のカードID `10600518`（【羽休み】）の `cost_SN` を `30000`（コスト3）から `20000`（コスト2）に修正しました。

> `cost_SN` はコストの実値を 10,000 倍した整数として格納されます（例: 20000 = コスト2）。

## テスト

TDD で実施しました。

- まず `tests/unit/lib/issue-75-karu-skill1-cost.test.ts` に失敗するテストを作成し、修正前に `cost_SN: 30000` が返ることを確認
- `cardDb.ts` を修正後、テストが通ることを確認
- 全テスト（35ファイル・167テスト）がパスすることも確認済み

Fixes: #75