### PR TITLE
ドラミスの共生オプションでナンバー指定が先頭になる問題を修正

### DIFF
--- a/lib/cardDb.ts
+++ b/lib/cardDb.ts
@@ -13802,16 +13802,16 @@ export const cards: Record<string, Card> =
           "des": 80610278
         },
         {
-          "actId": 96300013,
-          "des": 80611603
-        },
-        {
           "actId": 96300011,
           "des": 80611604
         },
         {
           "actId": 96300014,
           "des": 80611605
+        },
+        {
+          "actId": 96300013,
+          "des": 80611603
         }
       ],
       "tagList": [

--- a/tests/unit/lib/issue-74-dramis-symbiosis-option-order.test.ts
+++ b/tests/unit/lib/issue-74-dramis-symbiosis-option-order.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest"
+
+describe("Issue #74: ドラミス共生オプション順", () => {
+  it("カード10600510のナンバー指定オプションが末尾にある", async () => {
+    const { cards } = await import("@/lib/cardDb")
+    const targetCard = cards["10600510"]
+
+    expect(targetCard).toBeDefined()
+
+    const actionOptions = (targetCard.ExActList ?? []).map((item) => item.des)
+    expect(actionOptions).toEqual([80610277, 80610278, 80611604, 80611605, 80611603])
+    expect(actionOptions.at(-1)).toBe(80611603)
+  })
+})


### PR DESCRIPTION
ドラミスの共生カード(10600510)で、オプション順がゲーム内と異なりナンバー指定が上に出ていたため、デッキコード貼り付け時に意図した指定がずれる問題がありました。ゲーム内準拠でナンバー指定を最下段に配置し、指定解釈のズレを防ぎます.

## 変更内容
- `lib/cardDb.ts` の `10600510.ExActList` を並び替え
  - `80610277` (隊長指定)
  - `80610278`
  - `80611604`
  - `80611605`
  - `80611603` (ナンバー指定, 末尾)
- 回帰防止として `tests/unit/lib/issue-74-dramis-symbiosis-option-order.test.ts` を追加
  - 対象カードのオプション順を固定で検証
  - ナンバー指定が末尾であることを検証

## 補足
- `useType` の保存形式やUIロジックは変更していません。今回の修正は対象カードのデータ順の是正に限定しています。

Fixes: #74