### PR TITLE
Add specified ally priority option

### DIFF
--- a/components/card-settings/UsageSettings.tsx
+++ b/components/card-settings/UsageSettings.tsx
@@ -165,6 +165,13 @@ export function UsageSettings({
             // Calculate option index (starting after ExCondList options)
             const condListLength = card.ExCondList?.length || 0
             const optionIndex = index + 3 + condListLength
+            const isNumCond = act.isNumCond === true
+            const minNum = act.minNum || 0
+            const maxNum =
+              act.interValNum && act.numDuration ? minNum + (act.interValNum - 1) * act.numDuration : 100
+            const step = act.numDuration || 1
+            const currentValue =
+              useParamMap[optionIndex.toString()] !== undefined ? useParamMap[optionIndex.toString()] : minNum
 
             // Generate language key
             const textKey = `text_${act.des}`
@@ -179,6 +186,30 @@ export function UsageSettings({
                   <div className="font-medium flex items-center">
                     {/* Text */}
                     <span>{t(textKey) || textKey}</span>
+                    {isNumCond && (
+                      <div className="ml-2 flex items-center" onClick={(e) => e.stopPropagation()}>
+                        <button
+                          className="w-4 h-6 bg-black/20 rounded-l flex items-center justify-center"
+                          onClick={() => onParamChange(optionIndex, currentValue - step, minNum, maxNum)}
+                        >
+                          <ChevronLeft className="w-4 h-4" />
+                        </button>
+                        <span
+                          className={`font-mono inline-block text-right ${
+                            act.typeEnum === "percent" ? "w-[3ch]" : "w-[2ch]"
+                          }`}
+                        >
+                          {currentValue}
+                          {act.typeEnum === "percent" ? "%" : ""}
+                        </span>
+                        <button
+                          className="w-4 h-6 bg-black/20 rounded-r flex items-center justify-center"
+                          onClick={() => onParamChange(optionIndex, currentValue + step, minNum, maxNum)}
+                        >
+                          <ChevronRight className="w-4 h-4" />
+                        </button>
+                      </div>
+                    )}
                   </div>
                 </div>
               </div>

--- a/components/skill-card.tsx
+++ b/components/skill-card.tsx
@@ -75,9 +75,10 @@ export function SkillCard({
   // 사용 조건 텍스트 가져오기
 
   const shouldShowParam = () => {
-    if (useType < 3 || !card.ExCondList) return false
+    if (useType < 3 || (!card.ExCondList && !card.ExActList)) return false
 
     const condListLength = card.ExCondList.length
+    const actListLength = card.ExActList?.length || 0
 
     // useType이 ExCondList 범위에 있는지 확인
     if (useType >= 3 && useType < 3 + condListLength) {
@@ -85,6 +86,12 @@ export function SkillCard({
       const cond = card.ExCondList[condIndex]
       // isNumCond가 true인지 확인
       return cond.isNumCond === true
+    }
+
+    if (card.ExActList && useType >= 3 + condListLength && useType < 3 + condListLength + actListLength) {
+      const actIndex = useType - 3 - condListLength
+      const act = card.ExActList[actIndex]
+      return act.isNumCond === true
     }
 
     return false

--- a/lib/cardDb.ts
+++ b/lib/cardDb.ts
@@ -37,7 +37,17 @@ export const cards: Record<string, Card> =
       "color": "Red",
       "cost_SN": 30000,
       "cardType": "Normal",
-      "ExCondList": [],
+      "ExCondList": [
+        {
+          "condId": 96200036,
+          "des": 80611607,
+          "interValNum": 5,
+          "isNumCond": true,
+          "minNum": 1,
+          "numDuration": 1,
+          "typeEnum": "number"
+        }
+      ],
       "ExActList": [],
       "tagList": [
         {
@@ -13803,15 +13813,6 @@ export const cards: Record<string, Card> =
           "actId": 96300013,
           "des": 80611603
         },
-        {
-          "actId": 96200036,
-          "des": 80611607,
-          "interValNum": 5,
-          "isNumCond": true,
-          "minNum": 1,
-          "numDuration": 1,
-          "typeEnum": "number"
-        }
       ],
       "tagList": [
         {

--- a/lib/cardDb.ts
+++ b/lib/cardDb.ts
@@ -13781,17 +13781,7 @@ export const cards: Record<string, Card> =
       "color": "Purple",
       "cost_SN": 30000,
       "cardType": "UseOnce",
-      "ExCondList": [
-        {
-          "condId": 96200036,
-          "des": 80611607,
-          "interValNum": 5,
-          "isNumCond": true,
-          "minNum": 1,
-          "numDuration": 1,
-          "typeEnum": "number"
-        }
-      ],
+      "ExCondList": [],
       "ExActList": [
         {
           "actId": 96300009,
@@ -13812,6 +13802,15 @@ export const cards: Record<string, Card> =
         {
           "actId": 96300013,
           "des": 80611603
+        },
+        {
+          "actId": 96200036,
+          "des": 80611607,
+          "interValNum": 5,
+          "isNumCond": true,
+          "minNum": 1,
+          "numDuration": 1,
+          "typeEnum": "number"
         }
       ],
       "tagList": [

--- a/tests/unit/components/skill-card.test.tsx
+++ b/tests/unit/components/skill-card.test.tsx
@@ -140,4 +140,44 @@ describe("SkillCard", () => {
 
     expect(screen.getByText("text_after_attack")).toBeInTheDocument()
   })
+
+  it("ExActList の数値付き指定番号オプションでもパラメータを表示する", () => {
+    const card = {
+      id: 1001,
+      name: "card.name",
+      ownerId: 10000001,
+      ExCondList: [],
+      ExActList: [
+        { des: "after_attack" },
+        { des: "specified_ally", isNumCond: true, minNum: 1, interValNum: 5, numDuration: 1 },
+      ],
+    } as Card
+
+    const extraInfo = {
+      name: "skill.name",
+      desc: "skill.desc",
+      cost: 1,
+      amount: 1,
+      img_url: "/skill.png",
+      skillObj: {
+        id: 12300007,
+        leaderCardConditionDesc: "skill.validLeaderDesc",
+      } as Skill,
+    } as CardExtraInfo
+
+    render(
+      <SkillCard
+        card={card}
+        extraInfo={extraInfo}
+        onRemove={() => {}}
+        onEdit={() => {}}
+        isDisabled={false}
+        useType={4}
+        useParam={3}
+        leaderCharacter={10000001}
+      />,
+    )
+
+    expect(screen.getByText("text_specified_ally: 3")).toBeInTheDocument()
+  })
 })

--- a/tests/unit/components/usage-settings.test.tsx
+++ b/tests/unit/components/usage-settings.test.tsx
@@ -1,0 +1,35 @@
+/** @vitest-environment jsdom */
+import { render } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { UsageSettings } from "@/components/card-settings/UsageSettings"
+import type { Card } from "@/types"
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
+describe("UsageSettings", () => {
+  it("renders a numeric ExActList option with a parameter control", () => {
+    const card = {
+      id: 1001,
+      name: "card.name",
+      ExCondList: [],
+      ExActList: [
+        { des: "after_attack" },
+        { des: "specified_ally", isNumCond: true, minNum: 1, interValNum: 5, numDuration: 1 },
+      ],
+    } as Card
+
+    const { container } = render(
+      <UsageSettings card={card} useType={1} useParamMap={{}} onOptionSelect={() => {}} onParamChange={() => {}} />,
+    )
+
+    const options = container.querySelectorAll(".skill-option")
+    const numericOption = options[3]
+
+    expect(numericOption.textContent).toContain("text_specified_ally")
+    expect(numericOption.textContent).toContain("1")
+    expect(numericOption.querySelectorAll("button")).toHaveLength(2)
+  })
+})

--- a/types/index.ts
+++ b/types/index.ts
@@ -48,6 +48,10 @@ export interface Card {
   ExActList?: Array<{
     actId?: number
     des?: number
+    isNumCond?: boolean
+    interValNum?: number
+    minNum?: number
+    numDuration?: number
     typeEnum?: string
   }>
 }


### PR DESCRIPTION
This change adds the specified ally target option for the card priority UI so the formation-screen ally selection can be chosen directly from the priority settings.

### What changed
- Moved the `80611607` option into the bottom of the action list for the affected card metadata.
- Added support for numeric action options in the usage settings UI and skill card display.
- Extended the card setting type definitions to carry numeric metadata on action entries.
- Added regression tests for the new option and its parameter rendering.

### Notes
- The option now behaves like the other numbered priority targets, with a 1-5 selector.

Fixes: #73