### PR TITLE
fix: 藍鵲児の覚醒スキル説明が1段ずれる不具合を修正

### DIFF
--- a/lib/charDb.ts
+++ b/lib/charDb.ts
@@ -9072,6 +9072,9 @@ export const characters: Record<string, Character> =
     ],
     "breakthroughList": [
       {
+        "breakthroughId": 12101505
+      },
+      {
         "breakthroughId": 12101500
       },
       {
@@ -9085,9 +9088,6 @@ export const characters: Record<string, Character> =
       },
       {
         "breakthroughId": 12101504
-      },
-      {
-        "breakthroughId": 12101505
       }
     ],
     "line": 1,

--- a/tests/unit/lib/char-10001383.test.ts
+++ b/tests/unit/lib/char-10001383.test.ts
@@ -205,6 +205,21 @@ describe("Character 10001383 (藍鵲児 / Lanque)", () => {
       expect(char.breakthroughList?.length).toBeGreaterThanOrEqual(5)
     })
 
+    it("覚醒スキルの並びが基礎→Lv.1〜Lv.5の順になっている", async () => {
+      const { characters } = await import("@/lib/charDb")
+      const char = characters["10001383"]
+      const breakthroughIds = char.breakthroughList?.map((entry) => entry.breakthroughId)
+
+      expect(breakthroughIds).toEqual([
+        12101505,
+        12101500,
+        12101501,
+        12101502,
+        12101503,
+        12101504,
+      ])
+    })
+
     it("共鳴スキル全てが talentDb に存在する", async () => {
       const { characters } = await import("@/lib/charDb")
       const { talents } = await import("@/lib/talentDb")


### PR DESCRIPTION
藍鵲児の覚醒スキル表示でテキストが1段ずつずれていたため、覚醒IDの並びとUI前提の不整合を解消しました。

`BreakthroughsList` は `breakthroughList.slice(1)` で先頭要素(基礎覚醒)を除外してLv.1以降を表示する実装です。藍鵲児だけ基礎覚醒ID `12101505` が末尾に入っていたため、`lib/charDb.ts` の `10001383.breakthroughList` を基礎覚醒先頭の順序へ修正しました。

あわせて `tests/unit/lib/char-10001383.test.ts` に、覚醒IDが `12101505 -> 12101500..12101504` の順であることを検証する回帰テストを追加し、同種のずれを再発しにくくしています。

Fixes: #81