### PR TITLE
fix: 陳書閑「目覚めの単叢」にナンバー指定オプションを追加

### DIFF
--- a/lib/cardDb.ts
+++ b/lib/cardDb.ts
@@ -13958,6 +13958,14 @@ export const cards: Record<string, Card> =
         {
           "actId": 96300010,
           "des": 80610278
+        },
+        {
+          "des": 80611607,
+          "isNumCond": true,
+          "interValNum": 5,
+          "minNum": 1,
+          "numDuration": 1,
+          "typeEnum": "number"
         }
       ],
       "tagList": [

--- a/tests/unit/lib/issue-80-shuxian-awakening-number-option.test.ts
+++ b/tests/unit/lib/issue-80-shuxian-awakening-number-option.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest"
+
+import { cards } from "@/lib/cardDb"
+
+describe("Issue #80: 陳書閑 目覚めの単叢 ナンバー指定", () => {
+  it("カード10600523の優先度オプション末尾にナンバー指定を追加する", () => {
+    const targetCard = cards["10600523"]
+    expect(targetCard).toBeDefined()
+
+    const actionOptions = targetCard.ExActList ?? []
+    expect(actionOptions.map((item) => item.des)).toEqual([80610277, 80610278, 80611607])
+
+    const numberOption = actionOptions.at(-1)
+    expect(numberOption).toEqual(
+      expect.objectContaining({
+        des: 80611607,
+        isNumCond: true,
+        minNum: 1,
+        interValNum: 5,
+        numDuration: 1,
+        typeEnum: "number",
+      }),
+    )
+  })
+})


### PR DESCRIPTION
## Why
Issue #80 で、陳書閑の「目覚めの単叢」に対象ナンバー指定を追加し、優先度オプションの最下部に配置する要望がありました。現状は対象指定が固定選択のみで、番号指定ができませんでした。

## What changed
- `lib/cardDb.ts`
  - カード `10600523` の `ExActList` 末尾に、`des: 80611607` の数値指定オプションを追加
  - 数値条件は既存仕様に合わせて `isNumCond: true`, `minNum: 1`, `interValNum: 5`, `numDuration: 1`, `typeEnum: "number"` を設定
  - 末尾追加により、UI上で優先度オプションの最下部に表示されます
- `tests/unit/lib/issue-80-shuxian-awakening-number-option.test.ts`
  - オプション順序と数値条件メタデータを検証する回帰テストを追加

## Notes
- 表示文言キーは既存の `text_80611607` を流用し、新規翻訳キーは追加していません。

Fixes: #80