### PR TITLE
fix: ドラミス共生の優先度末尾オプションにナンバー指定を復元

### DIFF
--- a/lib/cardDb.ts
+++ b/lib/cardDb.ts
@@ -13811,7 +13811,12 @@ export const cards: Record<string, Card> =
         },
         {
           "actId": 96300013,
-          "des": 80611603
+          "des": 80611603,
+          "isNumCond": true,
+          "interValNum": 5,
+          "minNum": 1,
+          "numDuration": 1,
+          "typeEnum": "number"
         },
       ],
       "tagList": [

--- a/tests/unit/lib/issue-79-dramis-symbiosis-number-option.test.ts
+++ b/tests/unit/lib/issue-79-dramis-symbiosis-number-option.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest"
+
+import { cards } from "@/lib/cardDb"
+
+describe("Issue #79: ドラミス共生 ナンバー指定", () => {
+  it("カード10600510の優先度オプション末尾にナンバー指定を設定する", () => {
+    const targetCard = cards["10600510"]
+    expect(targetCard).toBeDefined()
+
+    const actionOptions = targetCard.ExActList ?? []
+    expect(actionOptions.map((item) => item.des)).toEqual([80610277, 80610278, 80611604, 80611605, 80611603])
+
+    const numberOption = actionOptions.at(-1)
+    expect(numberOption).toEqual(
+      expect.objectContaining({
+        des: 80611603,
+        isNumCond: true,
+        minNum: 1,
+        interValNum: 5,
+        numDuration: 1,
+        typeEnum: "number",
+      }),
+    )
+  })
+})


### PR DESCRIPTION
Issue #74 のオプション順修正後、ドラミス共生カード(10600510)の優先度末尾オプションからナンバー指定が消えており、数値入力できない状態になっていました。今回の変更で、失われていた数値指定設定を復元します。

## 変更内容
- `lib/cardDb.ts` の `10600510` `ExActList` 末尾 (`des: 80611603`) にナンバー指定プロパティを追加
  - `isNumCond: true`
  - `minNum: 1`
  - `interValNum: 5`
  - `numDuration: 1`
  - `typeEnum: "number"`
- TDD として `tests/unit/lib/issue-79-dramis-symbiosis-number-option.test.ts` を追加
  - 既存の優先度オプション順を維持していること
  - 末尾オプションにナンバー指定が設定されていること

## 補足
- Issue #74 で確定したオプション順 `[80610277, 80610278, 80611604, 80611605, 80611603]` は変更していません。

Fixes: #79