### PR TITLE
美琪の秘話専線に優先度オプションを追加

### DIFF
--- a/lib/cardDb.ts
+++ b/lib/cardDb.ts
@@ -14739,7 +14739,24 @@ export const cards: Record<string, Card> =
       "cost_SN": 20000,
       "cardType": "Normal",
       "ExCondList": [],
-      "ExActList": [],
+      "ExActList": [
+        {
+          "actId": 96300009,
+          "des": 80610277
+        },
+        {
+          "actId": 96300010,
+          "des": 80610278
+        },
+        {
+          "des": 80611607,
+          "isNumCond": true,
+          "interValNum": 5,
+          "minNum": 1,
+          "numDuration": 1,
+          "typeEnum": "number"
+        }
+      ],
       "tagList": []
     },
     "10600574": {

--- a/tests/unit/lib/issue-91-meiqi-priority-options.test.ts
+++ b/tests/unit/lib/issue-91-meiqi-priority-options.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest"
+
+import { cards } from "@/lib/cardDb"
+
+describe("Issue #91: 美琪 秘話専線 優先度オプション", () => {
+  it("カード10600573の優先度オプションに3項目を追加する", () => {
+    const targetCard = cards["10600573"]
+    expect(targetCard).toBeDefined()
+
+    const actionOptions = targetCard.ExActList ?? []
+    expect(actionOptions.map((item) => item.des)).toEqual([80610277, 80610278, 80611607])
+
+    const numberOption = actionOptions.at(-1)
+    expect(numberOption).toEqual(
+      expect.objectContaining({
+        des: 80611607,
+        isNumCond: true,
+        minNum: 1,
+        interValNum: 5,
+        numDuration: 1,
+        typeEnum: "number",
+      }),
+    )
+  })
+})


### PR DESCRIPTION
美琪の「秘話専線」(card: 10600573) で、指定した優先度での発動先を選べない状態だったため、Issue #91 の要件に合わせてカード固有の優先度オプションを追加しました。

## 変更内容
- `lib/cardDb.ts`
  - `cards["10600573"].ExActList` に以下を追加
    - `80610277`: 隊長をターゲットにして発動する
    - `80610278`: 攻撃力が最も高い味方をターゲットにして発動する
    - `80611607`: 編成番号指定(1-5)
      - `isNumCond: true`
      - `minNum: 1`
      - `interValNum: 5`
      - `numDuration: 1`
      - `typeEnum: "number"`
- `tests/unit/lib/issue-91-meiqi-priority-options.test.ts`
  - ExActList の順序と番号指定オプションのメタデータを検証する回帰テストを追加

## テスト
- `pnpm test --run tests/unit/lib/issue-79-dramis-symbiosis-number-option.test.ts tests/unit/lib/issue-80-shuxian-awakening-number-option.test.ts tests/unit/lib/issue-91-meiqi-priority-options.test.ts`

Fixes: #91