### PR TITLE
fix: align Meiqi signal overwrite import with device codes

### DIFF
--- a/hooks/deck-builder/index.ts
+++ b/hooks/deck-builder/index.ts
@@ -466,6 +466,7 @@ export function useDeckBuilder(data: Database | null) {
           // 카드의 equipIdList 처리
           preset.cardList.forEach((presetCard: PresetCard) => {
             if (presetCard.equipIdList && Array.isArray(presetCard.equipIdList) && presetCard.equipIdList.length > 0) {
+              const presetCardId = String(presetCard.id)
               // 각 장비 ID에 대해 처리
               presetCard.equipIdList.forEach((equipId: string) => {
                 // 이미 장착된 장비는 건너뛰기
@@ -487,7 +488,7 @@ export function useDeckBuilder(data: Database | null) {
                 if (itemSkillMap && itemSkillMap.relatedSkills) {
                   for (const skillId of itemSkillMap.relatedSkills) {
                     const skill = getSkill(skillId)
-                    if (skill && skill.cardID && skill.cardID.toString() === presetCard.id) {
+                    if (skill && skill.cardID && skill.cardID.toString() === presetCardId) {
                       isValidEquipment = true
                       break
                     }
@@ -535,7 +536,7 @@ export function useDeckBuilder(data: Database | null) {
 
           // 프리셋의 카드 목록을 처리하여 새 카드 배열 생성
           preset.cardList.forEach((presetCard: PresetCard) => {
-            const cardId = presetCard.id
+            const cardId = String(presetCard.id)
             // 현재 카드 목록에서 해당 ID를 가진 카드 찾기
             const existingCard = currentCards.find((card) => card.id === cardId)
 
@@ -566,7 +567,7 @@ export function useDeckBuilder(data: Database | null) {
           })
 
           // 2. 프리셋의 cardList에 없는 카드 중 현재 선택된 카드 목록에 있는 카드 추가
-          const presetCardIds = new Set(preset.cardList.map((card: PresetCard) => card.id))
+          const presetCardIds = new Set(preset.cardList.map((card: PresetCard) => String(card.id)))
 
           currentCards.forEach((card) => {
             // 이미 추가되지 않은 카드만 추가

--- a/lib/imgDb.ts
+++ b/lib/imgDb.ts
@@ -1600,6 +1600,7 @@ export const images: Record<string, string> = {
   "char_10001393": "https://patchwiki.biligame.com/images/resonance/e/e7/50629lpnfu11s1av23fw3d8jaav8umr.png",
   "skill_12304489": "https://patchwiki.biligame.com/images/resonance/3/3d/9de4rii6wdre0gpb0y7vubudb817cqq.png",
   "skill_12304490": "https://patchwiki.biligame.com/images/resonance/c/cd/s4j776xpwqflnholssaduef1awkwkyf.png",
+  "skill_12304492": "https://patchwiki.biligame.com/images/resonance/5/55/s3imkm4v1euso922bms1o7rls3gaguu.png",
   "skill_12304861": "https://patchwiki.biligame.com/images/resonance/6/61/di4j8ive1aho94uackoc4m1hp83sf2h.png",
   "talent_12824006": "https://patchwiki.biligame.com/images/resonance/6/6a/904bz59x0m6f2pvx24huwfkpwos3tcp.png",
   "talent_12824007": "https://patchwiki.biligame.com/images/resonance/5/5c/pgzn40v7c7nb4pnhww7liwi6arss09d.png",

--- a/lib/imgDb.ts
+++ b/lib/imgDb.ts
@@ -1600,7 +1600,7 @@ export const images: Record<string, string> = {
   "char_10001393": "https://patchwiki.biligame.com/images/resonance/e/e7/50629lpnfu11s1av23fw3d8jaav8umr.png",
   "skill_12304489": "https://patchwiki.biligame.com/images/resonance/3/3d/9de4rii6wdre0gpb0y7vubudb817cqq.png",
   "skill_12304490": "https://patchwiki.biligame.com/images/resonance/c/cd/s4j776xpwqflnholssaduef1awkwkyf.png",
-  "skill_12304492": "https://patchwiki.biligame.com/images/resonance/5/55/s3imkm4v1euso922bms1o7rls3gaguu.png",
+  "skill_12304492": "https://resonance.wikiru.jp/attach2/E7BE8EE790AA_6861736569315F312E706E67.png",
   "skill_12304861": "https://patchwiki.biligame.com/images/resonance/6/61/di4j8ive1aho94uackoc4m1hp83sf2h.png",
   "talent_12824006": "https://patchwiki.biligame.com/images/resonance/6/6a/904bz59x0m6f2pvx24huwfkpwos3tcp.png",
   "talent_12824007": "https://patchwiki.biligame.com/images/resonance/5/5c/pgzn40v7c7nb4pnhww7liwi6arss09d.png",

--- a/tests/unit/hooks/issue-92-import-preset-id-normalization.test.tsx
+++ b/tests/unit/hooks/issue-92-import-preset-id-normalization.test.tsx
@@ -1,0 +1,129 @@
+/** @vitest-environment jsdom */
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { useDeckBuilder } from "@/hooks/deck-builder"
+import type { Database } from "@/types"
+
+const t = Object.assign(
+  (key: string) => key,
+  {
+    rich: (key: string) => key,
+  },
+)
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => t,
+}))
+
+const mockData: Database = {
+  characters: {
+    "10001393": {
+      id: 10001393,
+      name: "char.10001393.name",
+      quality: "FiveStar",
+      tk_SN: 0,
+      skillList: [
+        { num: 2, skillId: 12304489 },
+        { num: 2, skillId: 12304490 },
+        { num: 1, skillId: 12304861 },
+      ],
+    },
+  },
+  cards: {
+    "10600474": { id: 10600474, name: "card.10600474.name", ExCondList: [], ExActList: [] },
+    "10600571": { id: 10600571, name: "card.10600571.name", ExCondList: [], ExActList: [] },
+    "10600572": { id: 10600572, name: "card.10600572.name", ExCondList: [], ExActList: [] },
+    "10600573": { id: 10600573, name: "card.10600573.name", ExCondList: [], ExActList: [] },
+    "10600574": { id: 10600574, name: "card.10600574.name", ExCondList: [], ExActList: [] },
+  },
+  skills: {
+    "12304489": {
+      id: 12304489,
+      name: "skill.12304489.name",
+      mod: "",
+      description: "skill.12304489.description",
+      detailDescription: "skill.12304489.detailDescription",
+      ExSkillList: [],
+      cardID: 10600573,
+    },
+    "12304490": {
+      id: 12304490,
+      name: "skill.12304490.name",
+      mod: "",
+      description: "skill.12304490.description",
+      detailDescription: "skill.12304490.detailDescription",
+      ExSkillList: [],
+      cardID: 10600571,
+    },
+    "12304492": {
+      id: 12304492,
+      name: "skill.12304492.name",
+      mod: "",
+      description: "skill.12304492.description",
+      detailDescription: "skill.12304492.detailDescription",
+      ExSkillList: [],
+      cardID: 10600572,
+    },
+    "12304861": {
+      id: 12304861,
+      name: "skill.12304861.name",
+      mod: "",
+      description: "skill.12304861.description",
+      detailDescription: "skill.12304861.detailDescription",
+      ExSkillList: [],
+      cardID: 10600574,
+    },
+  },
+  breakthroughs: {},
+  talents: {},
+  images: {},
+  charSkillMap: {
+    "10001393": {
+      skills: [12304489, 12304490, 12304861],
+      relatedSkills: [12304492],
+      notFromCharacters: [],
+    },
+  },
+  itemSkillMap: {},
+}
+
+describe("Issue #92: 実機コードインポート時のカードID正規化", () => {
+  it("数値IDで来ても selectedCards のIDを文字列で統一し、美琪カードが重複しない", async () => {
+    const { result } = renderHook(() => useDeckBuilder(mockData))
+
+    const presetFromDevice = {
+      roleList: [10001393, -1, -1, -1, -1],
+      header: 10001393,
+      cardList: [
+        { id: 10600574, useType: 1, useParam: -1, targetType: 0, equipIdList: [] },
+        { id: 10600571, useType: 3, useParam: -1, targetType: 0, equipIdList: [] },
+        { id: 10600573, useType: 4, useParam: -1, targetType: 0, equipIdList: [] },
+        { id: 10600572, useType: 5, useParam: 2, targetType: 0, equipIdList: [] },
+      ],
+      isLeaderCardOn: true,
+      isSpCardOn: true,
+      keepCardNum: 0,
+      discardType: 1,
+      otherCard: 0,
+    }
+
+    act(() => {
+      const importResult = result.current.importPresetObject(presetFromDevice as never, true)
+      expect(importResult.success).toBe(true)
+    })
+
+    await waitFor(() => {
+      expect(result.current.selectedCards.length).toBeGreaterThan(0)
+    })
+
+    expect(result.current.selectedCards.every((card) => typeof card.id === "string")).toBe(true)
+
+    const meiqiCardIds = result.current.selectedCards
+      .map((card) => String(card.id))
+      .filter((id) => ["10600571", "10600572", "10600573", "10600574"].includes(id))
+
+    expect(meiqiCardIds).toEqual(["10600574", "10600571", "10600573", "10600572"])
+    expect(new Set(meiqiCardIds).size).toBe(4)
+  })
+})

--- a/tests/unit/hooks/issue-92-import-preset-id-normalization.test.tsx
+++ b/tests/unit/hooks/issue-92-import-preset-id-normalization.test.tsx
@@ -16,6 +16,41 @@ vi.mock("next-intl", () => ({
   useTranslations: () => t,
 }))
 
+vi.mock("@/hooks/deck-builder/use-battle", () => ({
+  useBattle: () => ({
+    battleSettings: {
+      isLeaderCardOn: true,
+      isSpCardOn: true,
+      keepCardNum: 0,
+      discardType: 0,
+      otherCard: 0,
+    },
+    updateBattleSettings: vi.fn(),
+  }),
+}))
+
+vi.mock("@/hooks/deck-builder/use-awakening", () => ({
+  useAwakening: () => ({
+    awakening: {},
+    setAwakening: vi.fn(),
+    setCharacterAwakening: vi.fn(),
+    removeCharacterAwakening: vi.fn(),
+    clearAllAwakening: vi.fn(),
+  }),
+}))
+
+vi.mock("@/hooks/deck-builder/use-presets", () => ({
+  usePresets: () => ({
+    exportPreset: vi.fn(),
+    exportPresetToString: vi.fn(),
+    importPreset: vi.fn(),
+    decodePresetString: vi.fn(),
+    createShareableUrl: vi.fn(),
+    createRootShareableUrl: vi.fn(),
+    createPresetObject: vi.fn(),
+  }),
+}))
+
 const mockData: Database = {
   characters: {
     "10001393": {

--- a/tests/unit/lib/issue-92-meiqi-collab-shot-image.test.ts
+++ b/tests/unit/lib/issue-92-meiqi-collab-shot-image.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest"
+
+import { images } from "@/lib/imgDb"
+
+describe("Issue #92: 美琪 協同射撃の画像マッピング", () => {
+  it("skill_12304492 が imgDb に登録されている", () => {
+    expect(images["skill_12304492"]).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Why
Device-exported deck codes can carry numeric `card.id` values. In Issue #92, that caused Meiqi's `信号上書き` priority behavior to diverge from in-game ordering after import, and `協同射撃` was missing its skill image.

## What changed
- Normalized imported preset `card.id` values to strings inside `importPresetObject` so card matching and set membership stay type-consistent during import.
- Applied the same normalization in equipment-related import checks that compare imported card IDs.
- Added missing image mapping for `skill_12304492` (`協同射撃`) in `lib/imgDb.ts`.
- Added regression tests:
  - `tests/unit/hooks/issue-92-import-preset-id-normalization.test.tsx`
  - `tests/unit/lib/issue-92-meiqi-collab-shot-image.test.ts`

## Notes for reviewers
The key fix is runtime normalization at import boundaries. This preserves existing preset/type contracts while preventing mixed `number`/`string` ID state that can distort ordering logic.

Fixes: #92