### PR TITLE
ティスタル「青翠の羽」の優先度オプションを追加

### DIFF
--- a/lib/cardDb.ts
+++ b/lib/cardDb.ts
@@ -4541,6 +4541,19 @@ export const cards: Record<string, Card> =
         {
           "actId": 96300007,
           "des": 80608012
+        },
+        {
+          "actId": 96300015,
+          "des": 80611608
+        },
+        {
+          "actId": 96300017,
+          "des": 80611607,
+          "isNumCond": true,
+          "interValNum": 5,
+          "minNum": 1,
+          "numDuration": 1,
+          "typeEnum": "number"
         }
       ],
       "tagList": [
@@ -14333,6 +14346,19 @@ export const cards: Record<string, Card> =
         {
           "actId": 96300007,
           "des": 80608012
+        },
+        {
+          "actId": 96300015,
+          "des": 80611608
+        },
+        {
+          "actId": 96300017,
+          "des": 80611607,
+          "isNumCond": true,
+          "interValNum": 5,
+          "minNum": 1,
+          "numDuration": 1,
+          "typeEnum": "number"
         }
       ],
       "tagList": []

--- a/tests/unit/lib/issue-88-tistal-priority-options.test.ts
+++ b/tests/unit/lib/issue-88-tistal-priority-options.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest"
+
+import { cards } from "@/lib/cardDb"
+
+describe("Issue #88: ティスタル 青翠の羽 優先度オプション", () => {
+  it("カード10600529の優先度オプションを指定順で保持する", () => {
+    const targetCard = cards["10600529"]
+    expect(targetCard).toBeDefined()
+
+    const actionOptions = targetCard.ExActList ?? []
+    expect(actionOptions.map((item) => item.des)).toEqual([80610277, 80610278, 80608012, 80611608, 80611607])
+
+    const numberOption = actionOptions.at(-1)
+    expect(numberOption).toEqual(
+      expect.objectContaining({
+        des: 80611607,
+        isNumCond: true,
+        minNum: 1,
+        interValNum: 5,
+        numDuration: 1,
+        typeEnum: "number",
+      }),
+    )
+  })
+})


### PR DESCRIPTION
ティスタルの「青翠の羽」(10600529) に、issue で指定された優先度オプション順を反映するための変更です。既存データでは選択肢が不足しており、対象指定の再現ができない状態でした。

## 変更内容
- `lib/cardDb.ts` の `10600529.ExActList` を以下の順に更新
  - `80610277` (隊長)
  - `80610278` (攻撃力最大の味方)
  - `80608012` (自身)
  - `80611608` (自身を除く攻撃力最大の味方)
  - `80611607` (編成番号指定)
- 末尾の `80611607` には number option 設定 (`minNum: 1`, `interValNum: 5`, `numDuration: 1`, `typeEnum: "number"`) を付与
- TDD として `tests/unit/lib/issue-88-tistal-priority-options.test.ts` を追加し、並び順と number option 仕様を固定

## 補足
- issue本文の「地震を除く攻撃力が最も高い味方」は、既存キーとの整合から `80611608` (自身を除く攻撃力最大) として実装しています。

Fixes: #88