### PR TITLE
fix: 美琪の信号上書きが実機コード取込時に末尾化する問題を修正

### DIFF
--- a/hooks/deck-builder/utils.ts
+++ b/hooks/deck-builder/utils.ts
@@ -97,8 +97,45 @@ export function getAvailableCardIds(
       });
     }
 
-    // 다른 배열들(relatedSkills, notFromCharacters)도 유사하게 처리
-    // ...
+    if (charSkillMap.relatedSkills) {
+      charSkillMap.relatedSkills.forEach((skillId: number) => {
+        const skill = data.skills[skillId.toString()];
+        if (skill && skill.cardID) {
+          const cardId = skill.cardID.toString();
+          availableCardIds.add(cardId);
+
+          cardSources.push({
+            cardId,
+            source: {
+              type: "passive",
+              id: charId,
+              skillId,
+              slotIndex,
+            }
+          });
+        }
+      });
+    }
+
+    if (charSkillMap.notFromCharacters) {
+      charSkillMap.notFromCharacters.forEach((skillId: number) => {
+        const skill = data.skills[skillId.toString()];
+        if (skill && skill.cardID) {
+          const cardId = skill.cardID.toString();
+          availableCardIds.add(cardId);
+
+          cardSources.push({
+            cardId,
+            source: {
+              type: "passive",
+              id: charId,
+              skillId,
+              slotIndex,
+            }
+          });
+        }
+      });
+    }
   });
 
   // 장비에서 카드 ID 수집 - item_skill_map.json 사용

--- a/tests/unit/hooks/issue-96-import-meiqi-signal-overwrite-order.test.tsx
+++ b/tests/unit/hooks/issue-96-import-meiqi-signal-overwrite-order.test.tsx
@@ -1,0 +1,168 @@
+/** @vitest-environment jsdom */
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { useDeckBuilder } from "@/hooks/deck-builder"
+import type { Database } from "@/types"
+
+const t = Object.assign(
+  (key: string) => key,
+  {
+    rich: (key: string) => key,
+  },
+)
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => t,
+}))
+
+vi.mock("@/hooks/deck-builder/use-battle", () => ({
+  useBattle: () => ({
+    battleSettings: {
+      isLeaderCardOn: true,
+      isSpCardOn: true,
+      keepCardNum: 0,
+      discardType: 0,
+      otherCard: 0,
+    },
+    updateBattleSettings: vi.fn(),
+  }),
+}))
+
+vi.mock("@/hooks/deck-builder/use-awakening", () => ({
+  useAwakening: () => ({
+    awakening: {},
+    setAwakening: vi.fn(),
+    setCharacterAwakening: vi.fn(),
+    removeCharacterAwakening: vi.fn(),
+    clearAllAwakening: vi.fn(),
+  }),
+}))
+
+vi.mock("@/hooks/deck-builder/use-presets", () => ({
+  usePresets: () => ({
+    exportPreset: vi.fn(),
+    exportPresetToString: vi.fn(),
+    importPreset: vi.fn(),
+    decodePresetString: vi.fn(),
+    createShareableUrl: vi.fn(),
+    createRootShareableUrl: vi.fn(),
+    createPresetObject: vi.fn(),
+  }),
+}))
+
+const mockData: Database = {
+  characters: {
+    "10001393": {
+      id: 10001393,
+      name: "char.10001393.name",
+      quality: "FiveStar",
+      tk_SN: 0,
+      skillList: [
+        { num: 2, skillId: 12304489 },
+        { num: 2, skillId: 12304490 },
+        { num: 1, skillId: 12304861 },
+      ],
+    },
+  },
+  cards: {
+    "10600571": { id: 10600571, name: "card.10600571.name", ExCondList: [], ExActList: [] },
+    "10600572": { id: 10600572, name: "card.10600572.name", ExCondList: [], ExActList: [] },
+    "10600573": { id: 10600573, name: "card.10600573.name", ExCondList: [], ExActList: [] },
+    "10600574": { id: 10600574, name: "card.10600574.name", ExCondList: [], ExActList: [] },
+  },
+  skills: {
+    "12304489": {
+      id: 12304489,
+      name: "skill.12304489.name",
+      mod: "",
+      description: "skill.12304489.description",
+      detailDescription: "skill.12304489.detailDescription",
+      ExSkillList: [],
+      cardID: 10600573,
+    },
+    "12304490": {
+      id: 12304490,
+      name: "skill.12304490.name",
+      mod: "",
+      description: "skill.12304490.description",
+      detailDescription: "skill.12304490.detailDescription",
+      ExSkillList: [],
+      cardID: 10600571,
+    },
+    "12304492": {
+      id: 12304492,
+      name: "skill.12304492.name",
+      mod: "",
+      description: "skill.12304492.description",
+      detailDescription: "skill.12304492.detailDescription",
+      ExSkillList: [],
+      cardID: 10600572,
+    },
+    "12304861": {
+      id: 12304861,
+      name: "skill.12304861.name",
+      mod: "",
+      description: "skill.12304861.description",
+      detailDescription: "skill.12304861.detailDescription",
+      ExSkillList: [],
+      cardID: 10600574,
+    },
+  },
+  breakthroughs: {},
+  talents: {},
+  images: {},
+  charSkillMap: {
+    "10001393": {
+      skills: [12304489, 12304490, 12304861],
+      relatedSkills: [12304492],
+      notFromCharacters: [],
+    },
+  },
+  itemSkillMap: {},
+}
+
+describe("Issue #96: 実機コードの信号上書き優先度順保持", () => {
+  it("関連スキルIDのカードIDが実機コードと不一致でも cardList 順序で信号上書きを配置する", async () => {
+    const { result } = renderHook(() => useDeckBuilder(mockData))
+
+    const presetFromDevice = {
+      roleList: [10001393, -1, -1, -1, -1],
+      header: 10001393,
+      cardList: [
+        { id: 10600574, useType: 1, useParam: -1, targetType: 0, equipIdList: [] },
+        {
+          id: 99999999,
+          ownerId: 10001393,
+          skillId: 12304492,
+          useType: 4,
+          useParam: -1,
+          targetType: 0,
+          equipIdList: [],
+        },
+        { id: 10600571, useType: 3, useParam: -1, targetType: 0, equipIdList: [] },
+        { id: 10600573, useType: 4, useParam: -1, targetType: 0, equipIdList: [] },
+      ],
+      isLeaderCardOn: true,
+      isSpCardOn: true,
+      keepCardNum: 0,
+      discardType: 1,
+      otherCard: 0,
+    }
+
+    act(() => {
+      const importResult = result.current.importPresetObject(presetFromDevice as never)
+      expect(importResult.success).toBe(true)
+    })
+
+    await waitFor(() => {
+      expect(result.current.selectedCards.length).toBeGreaterThan(0)
+    })
+
+    const meiqiCardIds = result.current.selectedCards
+      .map((card) => String(card.id))
+      .filter((id) => ["10600571", "10600572", "10600573", "10600574"].includes(id))
+
+    expect(meiqiCardIds).toEqual(["10600574", "10600572", "10600571", "10600573"])
+  })
+})


### PR DESCRIPTION
実機コード取り込み時に、`cardList` 順序を優先すべきところで関連スキル由来カードが利用可能判定から漏れ、【信号上書き】の並びが末尾へ崩れるケースがありました。優先度表示を実機の並びに合わせるため、インポート時のカード解決ロジックを修正しました。

## 変更内容
- `getAvailableCardIds` で `charSkillMap.skills` に加えて、`relatedSkills` と `notFromCharacters` もカード候補へ含めるよう修正
- 上記により、実機コードの `cardList` 順が保持され、関連スキルカードが不正に末尾へ回される挙動を解消
- Issue #96 の再現シナリオを単体テストとして追加
  - 実機由来の不一致カードIDを含むケースでも、`cardList` 優先で並びが維持されることを検証

## 補足
- 既存の「`cardList` にないカードは末尾に追加」の挙動は維持しています。

Fixes: #96