### PR TITLE
feat: adjust Meiqi signal overwrite count option

### DIFF
--- a/lib/cardDb.ts
+++ b/lib/cardDb.ts
@@ -14745,10 +14745,18 @@ export const cards: Record<string, Card> =
       "ExCondList": [],
       "ExActList": [
         {
+          "actId": 96300009,
+          "des": 80610277
+        },
+        {
+          "actId": 96300010,
+          "des": 80610278
+        },
+        {
           "des": 80608005,
           "isNumCond": true,
-          "interValNum": 12,
-          "minNum": 0,
+          "interValNum": 2,
+          "minNum": 10,
           "numDuration": 1,
           "typeEnum": "number"
         }

--- a/tests/unit/lib/issue-101-meiqi-signal-overwrite-count-option.test.ts
+++ b/tests/unit/lib/issue-101-meiqi-signal-overwrite-count-option.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest"
+
+import { cards } from "@/lib/cardDb"
+
+describe("Issue #101: 美琪 信号上書きに枚数指定の追加", () => {
+  it("カード10600571の優先度オプションが指定順で、手札数条件が10〜11になる", () => {
+    const targetCard = cards["10600571"]
+    expect(targetCard).toBeDefined()
+
+    const actionOptions = targetCard.ExActList ?? []
+    expect(actionOptions.map((item) => item.des)).toEqual([80610277, 80610278, 80608005])
+
+    const handCountOption = actionOptions.at(-1)
+    expect(handCountOption).toEqual(
+      expect.objectContaining({
+        des: 80608005,
+        isNumCond: true,
+        minNum: 10,
+        interValNum: 2,
+        numDuration: 1,
+        typeEnum: "number",
+      }),
+    )
+  })
+})

--- a/tests/unit/lib/issue-97-meiqi-signal-overwrite-hand-count.test.ts
+++ b/tests/unit/lib/issue-97-meiqi-signal-overwrite-hand-count.test.ts
@@ -21,8 +21,8 @@ describe("Issue #97: 美琪 信号上書き 手札数優先度オプション", 
       expect.objectContaining({
         des: 80608005, // text_80608005 = "手札数≤"
         isNumCond: true,
-        minNum: 0,
-        interValNum: 12,
+        minNum: 10,
+        interValNum: 2,
         numDuration: 1,
         typeEnum: "number",
       }),


### PR DESCRIPTION
美琪の「信号上書き」で、実機コードに合わせた優先度指定と枚数指定ができるようにするための変更です。既存実装では手札数条件のみ(0-11)だったため、Issue #101の要件を満たしていませんでした。

## 変更内容
- `10600571` の `ExActList` を以下の順序に調整
  - 直接出す (`80610277`)
  - このカードは使用禁止 (`80610278`)
  - 手札数<= (`80608005`)
- 手札数条件を `0-11` から `10-11` に変更
  - `minNum: 10`
  - `interValNum: 2`
  - `numDuration: 1`
- Issue #101の検証テストを追加
- 既存のIssue #97テスト期待値を新仕様に合わせて更新

## 補足
`UsageSettings` は `ExActList` の並び順をそのまま表示順として扱うため、配列順を仕様どおりに固定しています。

Fixes: #101