### PR TITLE
Fix Meiqi signal overwrite recognition on device preset import

### DIFF
--- a/hooks/deck-builder/index.ts
+++ b/hooks/deck-builder/index.ts
@@ -583,8 +583,69 @@ export function useDeckBuilder(data: Database | null) {
             // 사용할 수 없는 카드 식별
             const unavailableCards = newCards.filter((card) =>!availableCardIds.has(card.id))
 
+            const applyUnavailableCardReplacement = (
+              unavailableCard: SelectedCard,
+              availableCardId: string,
+              foundSkillId?: number,
+            ) => {
+              const index = newCards.findIndex((card) => card.id === availableCardId)
+              if (index !== -1) {
+                newCards.splice(index, 1)
+              }
+
+              unavailableCard.id = availableCardId
+              if (foundSkillId !== undefined) {
+                unavailableCard.skillId = foundSkillId
+              }
+
+              if (!unavailableCard.sources) {
+                unavailableCard.sources = []
+              }
+              const sourcesForCard = cardSources.filter((cs) => cs.cardId === availableCardId)
+              sourcesForCard.forEach((cs) => {
+                unavailableCard.sources.push(cs.source)
+              })
+
+              if (foundSkillId === undefined) return
+
+              let isSpecialSkill = false
+              for (const charId in data.charSkillMap) {
+                const charSkillMap = data.charSkillMap[charId]
+                if (charSkillMap.notFromCharacters && charSkillMap.notFromCharacters.includes(foundSkillId)) {
+                  isSpecialSkill = true
+                  break
+                }
+              }
+
+              if (isSpecialSkill) {
+                unavailableCard.ownerId = 10000001
+              }
+            }
+
+            const tryReplaceWithOwnerRelatedSkillCard = (unavailableCard: SelectedCard): boolean => {
+              if (!unavailableCard.ownerId || unavailableCard.ownerId === 10000001) return false
+
+              const ownerSkillMap = data.charSkillMap[unavailableCard.ownerId.toString()]
+              if (!ownerSkillMap?.relatedSkills?.length) return false
+
+              for (const relatedSkillId of ownerSkillMap.relatedSkills) {
+                const relatedSkill = data.skills[relatedSkillId.toString()]
+                if (!relatedSkill?.cardID) continue
+
+                const relatedCardId = String(relatedSkill.cardID)
+                if (!availableCardIds.has(relatedCardId)) continue
+
+                applyUnavailableCardReplacement(unavailableCard, relatedCardId, relatedSkillId)
+                return true
+              }
+
+              return false
+            }
+
             // 사용할 수 없는 카드들에 대해 이름 매칭을 통한 대체 카드 찾기
             unavailableCards.forEach((unavailableCard) => {
+              let replaced = false
+
               // 스킬 ID가 있으면 해당 스킬의 이름 찾기
               if (unavailableCard.skillId && data.skills[unavailableCard.skillId]) {
                 const unavailableSkill = data.skills[unavailableCard.skillId]
@@ -614,51 +675,17 @@ export function useDeckBuilder(data: Database | null) {
                       // console.log(translatedAvailableSkillName +" 2")
                       // 번역된 이름으로 비교
                       if (translatedAvailableSkillName === translatedUnavailableSkillName) {
-                        const index = newCards.findIndex((card) => card.id === availableCardId)
-                        if (index !== -1) {
-                          newCards.splice(index, 1) // 인덱스 위치에서 1개의 원소를 삭제
-                        }
-
-                        // 이름이 일치하는 카드 발견, 카드 정보 교체
-                        unavailableCard.id = availableCardId
-                        unavailableCard.skillId = foundSkillId
-
-                        // 카드의 ownerId 업데이트
-                        const cardData = data.cards[availableCardId]
-                        // if (cardData && cardData.ownerId) {
-                        //   unavailableCard.ownerId = cardData.ownerId
-                        // }
-
-                        // 소스 정보 추가 - 이 부분이 누락되었습니다
-                        if (!unavailableCard.sources) {
-                          unavailableCard.sources = []
-                        }
-                        
-                        // 해당 카드 ID에 대한 모든 소스 정보 추가
-                        const sourcesForCard = cardSources.filter(cs => cs.cardId === availableCardId)
-                        sourcesForCard.forEach(cs => {
-                          unavailableCard.sources.push(cs.source)
-                        });
-
-                        // 특수 스킬 확인 (charSkillMap에서 notFromCharacters에 있는 경우)
-                        let isSpecialSkill = false
-                        for (const charId in data.charSkillMap) {
-                          const charSkillMap = data.charSkillMap[charId]
-                          if (charSkillMap.notFromCharacters && charSkillMap.notFromCharacters.includes(foundSkillId)) {
-                            isSpecialSkill = true
-                            break
-                          }
-                        }
-
-                        if (isSpecialSkill) {
-                          unavailableCard.ownerId = 10000001 // 특수 스킬의 경우 ownerId를 10000001로 설정
-                        }
-
+                        applyUnavailableCardReplacement(unavailableCard, availableCardId, foundSkillId)
+                        replaced = true
                         break
                       }
                     }
                   }
                 }
+              }
+
+              if (!replaced) {
+                tryReplaceWithOwnerRelatedSkillCard(unavailableCard)
               }
             })
           }

--- a/tests/unit/hooks/issue-100-import-meiqi-signal-overwrite-recognition.test.tsx
+++ b/tests/unit/hooks/issue-100-import-meiqi-signal-overwrite-recognition.test.tsx
@@ -1,0 +1,167 @@
+/** @vitest-environment jsdom */
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { useDeckBuilder } from "@/hooks/deck-builder"
+import type { Database } from "@/types"
+
+const t = Object.assign(
+  (key: string) => key,
+  {
+    rich: (key: string) => key,
+  },
+)
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => t,
+}))
+
+vi.mock("@/hooks/deck-builder/use-battle", () => ({
+  useBattle: () => ({
+    battleSettings: {
+      isLeaderCardOn: true,
+      isSpCardOn: true,
+      keepCardNum: 0,
+      discardType: 0,
+      otherCard: 0,
+    },
+    updateBattleSettings: vi.fn(),
+  }),
+}))
+
+vi.mock("@/hooks/deck-builder/use-awakening", () => ({
+  useAwakening: () => ({
+    awakening: {},
+    setAwakening: vi.fn(),
+    setCharacterAwakening: vi.fn(),
+    removeCharacterAwakening: vi.fn(),
+    clearAllAwakening: vi.fn(),
+  }),
+}))
+
+vi.mock("@/hooks/deck-builder/use-presets", () => ({
+  usePresets: () => ({
+    exportPreset: vi.fn(),
+    exportPresetToString: vi.fn(),
+    importPreset: vi.fn(),
+    decodePresetString: vi.fn(),
+    createShareableUrl: vi.fn(),
+    createRootShareableUrl: vi.fn(),
+    createPresetObject: vi.fn(),
+  }),
+}))
+
+const mockData: Database = {
+  characters: {
+    "10001393": {
+      id: 10001393,
+      name: "char.10001393.name",
+      quality: "FiveStar",
+      tk_SN: 0,
+      skillList: [
+        { num: 2, skillId: 12304489 },
+        { num: 2, skillId: 12304490 },
+        { num: 1, skillId: 12304861 },
+      ],
+    },
+  },
+  cards: {
+    "10600571": { id: 10600571, name: "card.10600571.name", ExCondList: [], ExActList: [] },
+    "10600572": { id: 10600572, name: "card.10600572.name", ExCondList: [], ExActList: [] },
+    "10600573": { id: 10600573, name: "card.10600573.name", ExCondList: [], ExActList: [] },
+    "10600574": { id: 10600574, name: "card.10600574.name", ExCondList: [], ExActList: [] },
+  },
+  skills: {
+    "12304489": {
+      id: 12304489,
+      name: "skill.12304489.name",
+      mod: "",
+      description: "skill.12304489.description",
+      detailDescription: "skill.12304489.detailDescription",
+      ExSkillList: [],
+      cardID: 10600573,
+    },
+    "12304490": {
+      id: 12304490,
+      name: "skill.12304490.name",
+      mod: "",
+      description: "skill.12304490.description",
+      detailDescription: "skill.12304490.detailDescription",
+      ExSkillList: [],
+      cardID: 10600571,
+    },
+    "12304492": {
+      id: 12304492,
+      name: "skill.12304492.name",
+      mod: "",
+      description: "skill.12304492.description",
+      detailDescription: "skill.12304492.detailDescription",
+      ExSkillList: [],
+      cardID: 10600572,
+    },
+    "12304861": {
+      id: 12304861,
+      name: "skill.12304861.name",
+      mod: "",
+      description: "skill.12304861.description",
+      detailDescription: "skill.12304861.detailDescription",
+      ExSkillList: [],
+      cardID: 10600574,
+    },
+  },
+  breakthroughs: {},
+  talents: {},
+  images: {},
+  charSkillMap: {
+    "10001393": {
+      skills: [12304489, 12304490, 12304861],
+      relatedSkills: [12304492],
+      notFromCharacters: [],
+    },
+  },
+  itemSkillMap: {},
+}
+
+describe("Issue #100: 実機コード読込時の信号上書き認識", () => {
+  it("signal overwrite の skillId が欠落していても cardList 順序で信号上書きを復元する", async () => {
+    const { result } = renderHook(() => useDeckBuilder(mockData))
+
+    const presetFromDevice = {
+      roleList: [10001393, -1, -1, -1, -1],
+      header: 10001393,
+      cardList: [
+        { id: 10600574, useType: 1, useParam: -1, targetType: 0, equipIdList: [] },
+        {
+          id: 99999999,
+          ownerId: 10001393,
+          useType: 4,
+          useParam: -1,
+          targetType: 0,
+          equipIdList: [],
+        },
+        { id: 10600571, useType: 3, useParam: -1, targetType: 0, equipIdList: [] },
+        { id: 10600573, useType: 4, useParam: -1, targetType: 0, equipIdList: [] },
+      ],
+      isLeaderCardOn: true,
+      isSpCardOn: true,
+      keepCardNum: 0,
+      discardType: 1,
+      otherCard: 0,
+    }
+
+    act(() => {
+      const importResult = result.current.importPresetObject(presetFromDevice as never)
+      expect(importResult.success).toBe(true)
+    })
+
+    await waitFor(() => {
+      expect(result.current.selectedCards.length).toBeGreaterThan(0)
+    })
+
+    const meiqiCardIds = result.current.selectedCards
+      .map((card) => String(card.id))
+      .filter((id) => ["10600571", "10600572", "10600573", "10600574"].includes(id))
+
+    expect(meiqiCardIds).toEqual(["10600574", "10600572", "10600571", "10600573"])
+  })
+})


### PR DESCRIPTION
## Why
When importing a device preset, Meiqi's signal overwrite card can arrive with inconsistent IDs (for example missing `skillId`). In that case, the previous fallback path failed to resolve it in place, so the card was effectively recognized late and pushed to the lowest priority.

## What changed
- Added an Issue #100 regression test for a device preset payload where the signal overwrite entry has no `skillId`.
- Refactored unavailable-card replacement into a shared helper so replacement keeps list position and source metadata consistently.
- Added a fallback that uses `ownerId` -> `charSkillMap.relatedSkills` to resolve the correct card when name-based matching does not apply.
- Kept existing behavior for regular name-based replacement and special-skill `ownerId` handling.

## Notes for reviewers
The new owner-related fallback runs only for unresolved cards with a concrete character `ownerId`, so the scope is limited to import recovery scenarios.

Fixes: #100