### PR TITLE
fix: 美琪 信号上書きの優先度オプションを仕様どおりに修正

### DIFF
--- a/lib/cardDb.ts
+++ b/lib/cardDb.ts
@@ -14745,18 +14745,10 @@ export const cards: Record<string, Card> =
       "ExCondList": [],
       "ExActList": [
         {
-          "actId": 96300009,
-          "des": 80610277
-        },
-        {
-          "actId": 96300010,
-          "des": 80610278
-        },
-        {
           "des": 80608005,
           "isNumCond": true,
-          "interValNum": 2,
-          "minNum": 10,
+          "interValNum": 12,
+          "minNum": 0,
           "numDuration": 1,
           "typeEnum": "number"
         }

--- a/tests/unit/lib/issue-101-meiqi-signal-overwrite-count-option.test.ts
+++ b/tests/unit/lib/issue-101-meiqi-signal-overwrite-count-option.test.ts
@@ -3,20 +3,20 @@ import { describe, expect, it } from "vitest"
 import { cards } from "@/lib/cardDb"
 
 describe("Issue #101: 美琪 信号上書きに枚数指定の追加", () => {
-  it("カード10600571の優先度オプションが指定順で、手札数条件が10〜11になる", () => {
+  it("カード10600571の優先度オプションが手札数条件のみで、0〜11になる", () => {
     const targetCard = cards["10600571"]
     expect(targetCard).toBeDefined()
 
     const actionOptions = targetCard.ExActList ?? []
-    expect(actionOptions.map((item) => item.des)).toEqual([80610277, 80610278, 80608005])
+    expect(actionOptions.map((item) => item.des)).toEqual([80608005])
 
     const handCountOption = actionOptions.at(-1)
     expect(handCountOption).toEqual(
       expect.objectContaining({
         des: 80608005,
         isNumCond: true,
-        minNum: 10,
-        interValNum: 2,
+        minNum: 0,
+        interValNum: 12,
         numDuration: 1,
         typeEnum: "number",
       }),

--- a/tests/unit/lib/issue-97-meiqi-signal-overwrite-hand-count.test.ts
+++ b/tests/unit/lib/issue-97-meiqi-signal-overwrite-hand-count.test.ts
@@ -21,8 +21,8 @@ describe("Issue #97: 美琪 信号上書き 手札数優先度オプション", 
       expect.objectContaining({
         des: 80608005, // text_80608005 = "手札数≤"
         isNumCond: true,
-        minNum: 10,
-        interValNum: 2,
+        minNum: 0,
+        interValNum: 12,
         numDuration: 1,
         typeEnum: "number",
       }),


### PR DESCRIPTION
## Why
美琪の「信号上書き」で、優先度オプションに不要なターゲット指定が表示され、手札数条件も 10-11 に固定されていました。Issue #108 の報告どおり、実際の仕様に合わせるため修正しました。

## What changed
- `10600571` の `ExActList` から不要な2項目（隊長ターゲット / 攻撃力最大味方ターゲット）を削除
- 手札数条件（`des: 80608005`）を `0-11` に変更
  - `minNum: 0`
  - `interValNum: 12`
  - `numDuration: 1`
- 既存の関連ユニットテスト2件を新仕様に更新

## Notes
- 「直接出す」「このカードは使用禁止」は既存UIの共通デフォルトオプションとして維持されます。

Fixes: #108