### PR TITLE
ドロシー派生5カードをデッキUIから非表示化

### DIFF
--- a/hooks/deck-builder/index.ts
+++ b/hooks/deck-builder/index.ts
@@ -10,7 +10,7 @@ import { useEquipment } from "./use-equipment"
 import { useBattle } from "./use-battle"
 import { usePresets } from "./use-presets"
 import { useAwakening } from "./use-awakening" // 각성 훅 추가
-import { getSkillById, getAvailableCardIds } from "./utils"
+import { getSkillById, getAvailableCardIds, shouldHideSkillFromUi } from "./utils"
 import { processSkillDescription } from "@/utils/skill-description"
 
 const findCharacterImageForCard = (_card: Card | SelectedCard | null | undefined) => undefined
@@ -132,6 +132,8 @@ export function useDeckBuilder(data: Database | null) {
       // 새로운 구조: relatedSkills 배열 처리 - 캐릭터 ID를 ownerId로 설정
       if (charSkillMap.relatedSkills) {
         charSkillMap.relatedSkills.forEach((skillId: number) => {
+          if (shouldHideSkillFromUi(characterId, skillId)) return
+
           const skill = getSkill(skillId)
           if (skill && skill.cardID) {
             const cardId = skill.cardID.toString()
@@ -629,6 +631,8 @@ export function useDeckBuilder(data: Database | null) {
               if (!ownerSkillMap?.relatedSkills?.length) return false
 
               for (const relatedSkillId of ownerSkillMap.relatedSkills) {
+                if (shouldHideSkillFromUi(unavailableCard.ownerId, relatedSkillId)) continue
+
                 const relatedSkill = data.skills[relatedSkillId.toString()]
                 if (!relatedSkill?.cardID) continue
 
@@ -768,6 +772,8 @@ export function useDeckBuilder(data: Database | null) {
       // 관련 스킬 처리
       if (charSkillMap.relatedSkills && Array.isArray(charSkillMap.relatedSkills)) {
         charSkillMap.relatedSkills.forEach((skillId: number) => {
+          if (shouldHideSkillFromUi(charId, skillId)) return
+
           const skill = data.skills[skillId.toString()]
           if (skill && skill.cardID) {
             cardSet.add(skill.cardID.toString())
@@ -816,6 +822,7 @@ export function useDeckBuilder(data: Database | null) {
     // 중요: selectedCards에서 모든 카드 ID를 cardSet에 추가
     // 이렇게 하면 장비에서 추가된 카드들도 포함됩니다
     selectedCards.forEach((card) => {
+      if (card.ownerId && card.skillId && shouldHideSkillFromUi(card.ownerId, card.skillId)) return
       cardSet.add(card.id)
     })
 

--- a/hooks/deck-builder/useDeckBuilderPage.tsx
+++ b/hooks/deck-builder/useDeckBuilderPage.tsx
@@ -6,6 +6,7 @@ import { processSkillDescription } from "@/utils/skill-description"
 import type { Card, Skill } from "@/types"
 
 import { useDeckBuilder } from "."
+import { shouldHideSkillFromUi } from "./utils"
 import { logEventWrapper } from "../../lib/firebase-analytics"
 import { decodePresetFromUrlParam } from "../../utils/presetCodec"
 import { getCurrentDeckId, removeCurrentDeckId, setCurrentDeckId, type SavedDeck } from "../../utils/local-storage"
@@ -146,6 +147,8 @@ export function useDeckBuilderPage(urlDeckCode: string | null) {
 
       if (charSkillMap.relatedSkills && Array.isArray(charSkillMap.relatedSkills)) {
         charSkillMap.relatedSkills.forEach((skillId: number) => {
+          if (shouldHideSkillFromUi(charId, skillId)) return
+
           const skill = data.skills[skillId.toString()]
           if (skill && skill.cardID) cardSet.add(skill.cardID.toString())
         })
@@ -179,6 +182,7 @@ export function useDeckBuilderPage(urlDeckCode: string | null) {
     })
 
     selectedCards.forEach((card) => {
+      if (card.ownerId && card.skillId && shouldHideSkillFromUi(card.ownerId, card.skillId)) return
       cardSet.add(card.id)
     })
 

--- a/hooks/deck-builder/utils.ts
+++ b/hooks/deck-builder/utils.ts
@@ -1,6 +1,15 @@
 import type { Database, Skill } from "../../types"
 import type { CardSource, SelectedCard, EquipmentSlot } from "./types"
 
+const hiddenSkillIdsByCharacter: Record<number, ReadonlySet<number>> = {
+  10001356: new Set([12304496, 12304497, 12304498, 12304499, 12304500]),
+}
+
+export function shouldHideSkillFromUi(characterId: number, skillId: number): boolean {
+  const hiddenSkills = hiddenSkillIdsByCharacter[characterId]
+  return hiddenSkills ? hiddenSkills.has(skillId) : false
+}
+
 // 캐릭터 ID로 캐릭터 정보 가져오기
 export function getCharacterById(data: Database | null, id: number) {
   if (!data || id === -1) return null
@@ -99,6 +108,8 @@ export function getAvailableCardIds(
 
     if (charSkillMap.relatedSkills) {
       charSkillMap.relatedSkills.forEach((skillId: number) => {
+        if (shouldHideSkillFromUi(charId, skillId)) return
+
         const skill = data.skills[skillId.toString()];
         if (skill && skill.cardID) {
           const cardId = skill.cardID.toString();

--- a/tests/unit/hooks/issue-110-dorothy-derived-cards-hidden.test.tsx
+++ b/tests/unit/hooks/issue-110-dorothy-derived-cards-hidden.test.tsx
@@ -1,0 +1,120 @@
+/** @vitest-environment jsdom */
+import { act, renderHook } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { useDeckBuilder } from "@/hooks/deck-builder"
+import type { Database } from "@/types"
+
+const t = Object.assign(
+  (key: string) => key,
+  {
+    rich: (key: string) => key,
+  },
+)
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => t,
+}))
+
+vi.mock("@/hooks/deck-builder/use-battle", () => ({
+  useBattle: () => ({
+    battleSettings: {
+      isLeaderCardOn: true,
+      isSpCardOn: true,
+      keepCardNum: 0,
+      discardType: 0,
+      otherCard: 0,
+    },
+    updateBattleSettings: vi.fn(),
+  }),
+}))
+
+vi.mock("@/hooks/deck-builder/use-awakening", () => ({
+  useAwakening: () => ({
+    awakening: {},
+    setAwakening: vi.fn(),
+    setCharacterAwakening: vi.fn(),
+    removeCharacterAwakening: vi.fn(),
+    clearAllAwakening: vi.fn(),
+  }),
+}))
+
+vi.mock("@/hooks/deck-builder/use-presets", () => ({
+  usePresets: () => ({
+    exportPreset: vi.fn(),
+    exportPresetToString: vi.fn(),
+    importPreset: vi.fn(),
+    decodePresetString: vi.fn(),
+    createShareableUrl: vi.fn(),
+    createRootShareableUrl: vi.fn(),
+    createPresetObject: vi.fn(),
+  }),
+}))
+
+const mockData: Database = {
+  characters: {
+    "10001356": {
+      id: 10001356,
+      name: "char.10001356.name",
+      quality: "FiveStar",
+      tk_SN: 0,
+      skillList: [
+        { num: 2, skillId: 12303430 },
+        { num: 2, skillId: 12304494 },
+        { num: 1, skillId: 12304495 },
+      ],
+    },
+  },
+  cards: {
+    "10600576": { id: 10600576, name: "card.10600576.name", ExCondList: [], ExActList: [] },
+    "10600577": { id: 10600577, name: "card.10600577.name", ExCondList: [], ExActList: [] },
+    "10600578": { id: 10600578, name: "card.10600578.name", ExCondList: [], ExActList: [] },
+    "10600579": { id: 10600579, name: "card.10600579.name", ExCondList: [], ExActList: [] },
+    "10600580": { id: 10600580, name: "card.10600580.name", ExCondList: [], ExActList: [] },
+    "10600581": { id: 10600581, name: "card.10600581.name", ExCondList: [], ExActList: [] },
+    "10600582": { id: 10600582, name: "card.10600582.name", ExCondList: [], ExActList: [] },
+    "10600583": { id: 10600583, name: "card.10600583.name", ExCondList: [], ExActList: [] },
+  },
+  skills: {
+    "12303430": { id: 12303430, name: "skill.12303430.name", mod: "", description: "", detailDescription: "", ExSkillList: [], cardID: 10600578 },
+    "12304494": { id: 12304494, name: "skill.12304494.name", mod: "", description: "", detailDescription: "", ExSkillList: [], cardID: 10600576 },
+    "12304495": { id: 12304495, name: "skill.12304495.name", mod: "", description: "", detailDescription: "", ExSkillList: [], cardID: 10600577 },
+    "12304496": { id: 12304496, name: "skill.12304496.name", mod: "", description: "", detailDescription: "", ExSkillList: [], cardID: 10600579 },
+    "12304497": { id: 12304497, name: "skill.12304497.name", mod: "", description: "", detailDescription: "", ExSkillList: [], cardID: 10600580 },
+    "12304498": { id: 12304498, name: "skill.12304498.name", mod: "", description: "", detailDescription: "", ExSkillList: [], cardID: 10600581 },
+    "12304499": { id: 12304499, name: "skill.12304499.name", mod: "", description: "", detailDescription: "", ExSkillList: [], cardID: 10600582 },
+    "12304500": { id: 12304500, name: "skill.12304500.name", mod: "", description: "", detailDescription: "", ExSkillList: [], cardID: 10600583 },
+  },
+  breakthroughs: {},
+  talents: {},
+  images: {},
+  charSkillMap: {
+    "10001356": {
+      skills: [12303430, 12304494, 12304495],
+      relatedSkills: [12304496, 12304497, 12304498, 12304499, 12304500],
+      notFromCharacters: [],
+    },
+  },
+  itemSkillMap: {},
+}
+
+describe("Issue #110: ドロシー・ローズモーン派生カードのUI非表示", () => {
+  it("対象5枚を availableCards と selectedCards から除外する", () => {
+    const { result } = renderHook(() => useDeckBuilder(mockData))
+
+    act(() => {
+      result.current.addCharacter(10001356, 0)
+    })
+
+    const availableCardIds = result.current.availableCards.map((item) => Number(item.card.id))
+    const selectedSkillIds = result.current.selectedCards
+      .map((card) => card.skillId)
+      .filter((skillId): skillId is number => typeof skillId === "number")
+
+    expect(availableCardIds).toEqual(expect.arrayContaining([10600576, 10600577, 10600578]))
+    expect(availableCardIds).not.toEqual(expect.arrayContaining([10600579, 10600580, 10600581, 10600582, 10600583]))
+
+    expect(selectedSkillIds).toEqual(expect.arrayContaining([12303430, 12304494, 12304495]))
+    expect(selectedSkillIds).not.toEqual(expect.arrayContaining([12304496, 12304497, 12304498, 12304499, 12304500]))
+  })
+})


### PR DESCRIPTION
実機では表示されないドロシー・ローズモーンの派生5カードがデッキ編集UIに出ていたため、表示整合性を合わせるためにUI側で非表示化しました。マスターデータは保持し、表示導出のみを制御しています。

## 変更内容
- `hooks/deck-builder/utils.ts` に `shouldHideSkillFromUi(characterId, skillId)` を追加
- `useDeckBuilder` と `useDeckBuilderPage` の relatedSkills 導出経路で対象5スキル(12304496-12304500)を除外
- `selectedCards` 由来で再混入しないよう cardSet 追加時にも同条件で除外
- 回帰テスト `tests/unit/hooks/issue-110-dorothy-derived-cards-hidden.test.tsx` を追加

## 補足
- 対象は表示ロジックのみで、`charSkillMap` / `skillDb` / `cardDb` のデータ定義には変更していません。

Fixes: #110