### PR TITLE
fix: infer Meiqi cards correctly for legacy preset imports

### DIFF
--- a/hooks/deck-builder/index.ts
+++ b/hooks/deck-builder/index.ts
@@ -622,70 +622,139 @@ export function useDeckBuilder(data: Database | null) {
               }
             }
 
-            const tryReplaceWithOwnerRelatedSkillCard = (unavailableCard: SelectedCard): boolean => {
-              if (!unavailableCard.ownerId || unavailableCard.ownerId === 10000001) return false
-
-              const ownerSkillMap = data.charSkillMap[unavailableCard.ownerId.toString()]
-              if (!ownerSkillMap?.relatedSkills?.length) return false
-
-              for (const relatedSkillId of ownerSkillMap.relatedSkills) {
-                const relatedSkill = data.skills[relatedSkillId.toString()]
-                if (!relatedSkill?.cardID) continue
-
-                const relatedCardId = String(relatedSkill.cardID)
-                if (!availableCardIds.has(relatedCardId)) continue
-
-                applyUnavailableCardReplacement(unavailableCard, relatedCardId, relatedSkillId)
-                return true
-              }
-
-              return false
+            const toPositiveInt = (value: unknown): number | undefined => {
+              const parsed = Number(value)
+              return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined
             }
 
-            // 사용할 수 없는 카드들에 대해 이름 매칭을 통한 대체 카드 찾기
-            unavailableCards.forEach((unavailableCard) => {
-              let replaced = false
+            const skillIdByCardId = new Map<string, number[]>()
+            for (const skillId in data.skills) {
+              const skill = data.skills[skillId]
+              if (!skill?.cardID) continue
+              const cardId = String(skill.cardID)
+              const skillNumId = Number(skillId)
+              const existing = skillIdByCardId.get(cardId)
+              if (existing) {
+                existing.push(skillNumId)
+              } else {
+                skillIdByCardId.set(cardId, [skillNumId])
+              }
+            }
 
-              // 스킬 ID가 있으면 해당 스킬의 이름 찾기
-              if (unavailableCard.skillId && data.skills[unavailableCard.skillId]) {
-                const unavailableSkill = data.skills[unavailableCard.skillId]
-                // 언어팩에서 번역된 스킬 이름 가져오기
-                const translatedUnavailableSkillName = t(unavailableSkill.name)
+            const tryReplaceWithOwnerSkillIndexCard = (unavailableCard: SelectedCard): boolean => {
+              const ownerId = toPositiveInt(unavailableCard.ownerId)
+              const skillIndex = toPositiveInt(unavailableCard.skillIndex)
+              if (!ownerId || !skillIndex) return false
 
-                // console.log(translatedUnavailableSkillName)
-                // 사용 가능한 카드들 중에서 같은 이름을 가진 카드 찾기
-                for (const availableCardId of availableCardIds) {
-                  // 해당 카드의 스킬 ID 찾기
-                  let foundSkillId: number | undefined
+              const owner = data.characters[ownerId.toString()]
+              const targetSkillId = owner?.skillList?.[skillIndex - 1]?.skillId
+              if (!targetSkillId) return false
 
-                  // 카드에 연결된 스킬 찾기
-                  for (const skillId in data.skills) {
-                    const skill = data.skills[skillId]
-                    if (skill.cardID && skill.cardID.toString() === availableCardId) {
-                      foundSkillId = Number(skillId)
-                      break
-                    }
-                  }
+              const targetSkill = data.skills[targetSkillId.toString()]
+              if (!targetSkill?.cardID) return false
 
-                  if (foundSkillId) {
-                    const availableSkill = data.skills[foundSkillId.toString()]
-                    if (availableSkill) {
-                      // 언어팩에서 번역된 사용 가능한 스킬 이름 가져오기
-                      const translatedAvailableSkillName = t(availableSkill.name)
-                      // console.log(translatedAvailableSkillName +" 2")
-                      // 번역된 이름으로 비교
-                      if (translatedAvailableSkillName === translatedUnavailableSkillName) {
-                        applyUnavailableCardReplacement(unavailableCard, availableCardId, foundSkillId)
-                        replaced = true
-                        break
-                      }
-                    }
+              const targetCardId = String(targetSkill.cardID)
+              if (!availableCardIds.has(targetCardId)) return false
+
+              applyUnavailableCardReplacement(unavailableCard, targetCardId, targetSkillId)
+              return true
+            }
+
+            const tryReplaceWithDirectSkillCard = (unavailableCard: SelectedCard): boolean => {
+              const skillId = toPositiveInt(unavailableCard.skillId)
+              if (!skillId) return false
+
+              const skill = data.skills[skillId.toString()]
+              if (!skill?.cardID) return false
+
+              const cardId = String(skill.cardID)
+              if (!availableCardIds.has(cardId)) return false
+
+              applyUnavailableCardReplacement(unavailableCard, cardId, skillId)
+              return true
+            }
+
+            const tryReplaceWithSkillNameKey = (unavailableCard: SelectedCard): boolean => {
+              const skillId = toPositiveInt(unavailableCard.skillId)
+              if (!skillId) return false
+
+              const unavailableSkill = data.skills[skillId.toString()]
+              if (!unavailableSkill?.name) return false
+
+              const matchedCandidates: Array<{ cardId: string; skillId: number }> = []
+              for (const [availableCardId, candidateSkillIds] of skillIdByCardId.entries()) {
+                if (!availableCardIds.has(availableCardId)) continue
+                for (const candidateSkillId of candidateSkillIds) {
+                  const candidateSkill = data.skills[candidateSkillId.toString()]
+                  if (candidateSkill?.name === unavailableSkill.name) {
+                    matchedCandidates.push({ cardId: availableCardId, skillId: candidateSkillId })
                   }
                 }
               }
 
+              if (matchedCandidates.length !== 1) return false
+              const match = matchedCandidates[0]
+              applyUnavailableCardReplacement(unavailableCard, match.cardId, match.skillId)
+              return true
+            }
+
+            const tryReplaceWithUniqueOwnerCandidate = (unavailableCard: SelectedCard): boolean => {
+              const ownerId = toPositiveInt(unavailableCard.ownerId)
+              if (!ownerId || ownerId === 10000001) return false
+
+              const owner = data.characters[ownerId.toString()]
+              if (!owner?.skillList?.length) return false
+
+              const ownerCardCandidates = owner.skillList
+                .map((item) => data.skills[item.skillId.toString()]?.cardID)
+                .filter((cardId): cardId is number => cardId !== undefined && cardId !== null)
+                .map((cardId) => String(cardId))
+                .filter((cardId) => availableCardIds.has(cardId))
+
+              const uniqueCandidates = Array.from(new Set(ownerCardCandidates))
+              if (uniqueCandidates.length !== 1) return false
+
+              const candidateCardId = uniqueCandidates[0]
+              const candidateSkillId = skillIdByCardId.get(candidateCardId)?.[0]
+              applyUnavailableCardReplacement(unavailableCard, candidateCardId, candidateSkillId)
+              return true
+            }
+
+            const tryReplaceWithUniqueOwnerRelatedCard = (unavailableCard: SelectedCard): boolean => {
+              const ownerId = toPositiveInt(unavailableCard.ownerId)
+              const skillId = toPositiveInt(unavailableCard.skillId)
+              const skillIndex = toPositiveInt(unavailableCard.skillIndex)
+              if (!ownerId || ownerId === 10000001 || skillId || skillIndex) return false
+
+              const ownerSkillMap = data.charSkillMap[ownerId.toString()]
+              if (!ownerSkillMap?.relatedSkills?.length) return false
+
+              const relatedCandidates = ownerSkillMap.relatedSkills
+                .map((relatedSkillId) => {
+                  const relatedSkill = data.skills[relatedSkillId.toString()]
+                  if (!relatedSkill?.cardID) return null
+                  const relatedCardId = String(relatedSkill.cardID)
+                  if (!availableCardIds.has(relatedCardId)) return null
+                  return { cardId: relatedCardId, skillId: relatedSkillId }
+                })
+                .filter((candidate): candidate is { cardId: string; skillId: number } => candidate !== null)
+
+              if (relatedCandidates.length !== 1) return false
+              const candidate = relatedCandidates[0]
+              applyUnavailableCardReplacement(unavailableCard, candidate.cardId, candidate.skillId)
+              return true
+            }
+
+            unavailableCards.forEach((unavailableCard) => {
+              const replaced =
+                tryReplaceWithOwnerSkillIndexCard(unavailableCard) ||
+                tryReplaceWithDirectSkillCard(unavailableCard) ||
+                tryReplaceWithSkillNameKey(unavailableCard) ||
+                tryReplaceWithUniqueOwnerRelatedCard(unavailableCard) ||
+                tryReplaceWithUniqueOwnerCandidate(unavailableCard)
+
               if (!replaced) {
-                tryReplaceWithOwnerRelatedSkillCard(unavailableCard)
+                // 曖昧なケースでは誤置換より未置換を優先する
               }
             })
           }

--- a/tests/unit/hooks/issue-109-import-meiqi-skill-inference.test.tsx
+++ b/tests/unit/hooks/issue-109-import-meiqi-skill-inference.test.tsx
@@ -1,0 +1,170 @@
+/** @vitest-environment jsdom */
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { useDeckBuilder } from "@/hooks/deck-builder"
+import type { Database } from "@/types"
+
+const t = Object.assign(
+  (key: string) => key,
+  {
+    rich: (key: string) => key,
+  },
+)
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => t,
+}))
+
+vi.mock("@/hooks/deck-builder/use-battle", () => ({
+  useBattle: () => ({
+    battleSettings: {
+      isLeaderCardOn: true,
+      isSpCardOn: true,
+      keepCardNum: 0,
+      discardType: 0,
+      otherCard: 0,
+    },
+    updateBattleSettings: vi.fn(),
+  }),
+}))
+
+vi.mock("@/hooks/deck-builder/use-awakening", () => ({
+  useAwakening: () => ({
+    awakening: {},
+    setAwakening: vi.fn(),
+    setCharacterAwakening: vi.fn(),
+    removeCharacterAwakening: vi.fn(),
+    clearAllAwakening: vi.fn(),
+  }),
+}))
+
+vi.mock("@/hooks/deck-builder/use-presets", () => ({
+  usePresets: () => ({
+    exportPreset: vi.fn(),
+    exportPresetToString: vi.fn(),
+    importPreset: vi.fn(),
+    decodePresetString: vi.fn(),
+    createShareableUrl: vi.fn(),
+    createRootShareableUrl: vi.fn(),
+    createPresetObject: vi.fn(),
+  }),
+}))
+
+const mockData: Database = {
+  characters: {
+    "10001393": {
+      id: 10001393,
+      name: "char.10001393.name",
+      quality: "FiveStar",
+      tk_SN: 0,
+      skillList: [
+        { num: 2, skillId: 12304489 },
+        { num: 2, skillId: 12304490 },
+        { num: 1, skillId: 12304861 },
+      ],
+    },
+  },
+  cards: {
+    "10600474": { id: 10600474, name: "card.10600474.name", ExCondList: [], ExActList: [] },
+    "10600571": { id: 10600571, name: "card.10600571.name", ExCondList: [], ExActList: [] },
+    "10600572": { id: 10600572, name: "card.10600572.name", ExCondList: [], ExActList: [] },
+    "10600573": { id: 10600573, name: "card.10600573.name", ExCondList: [], ExActList: [] },
+    "10600574": { id: 10600574, name: "card.10600574.name", ExCondList: [], ExActList: [] },
+  },
+  skills: {
+    "12303725": {
+      id: 12303725,
+      name: "skill.12303725.name",
+      mod: "",
+      description: "skill.12303725.description",
+      detailDescription: "skill.12303725.detailDescription",
+      ExSkillList: [],
+      cardID: 10600474,
+    },
+    "12304489": {
+      id: 12304489,
+      name: "skill.12304489.name",
+      mod: "",
+      description: "skill.12304489.description",
+      detailDescription: "skill.12304489.detailDescription",
+      ExSkillList: [],
+      cardID: 10600573,
+    },
+    "12304490": {
+      id: 12304490,
+      name: "skill.12304490.name",
+      mod: "",
+      description: "skill.12304490.description",
+      detailDescription: "skill.12304490.detailDescription",
+      ExSkillList: [],
+      cardID: 10600571,
+    },
+    "12304492": {
+      id: 12304492,
+      name: "skill.12304492.name",
+      mod: "",
+      description: "skill.12304492.description",
+      detailDescription: "skill.12304492.detailDescription",
+      ExSkillList: [],
+      cardID: 10600572,
+    },
+    "12304861": {
+      id: 12304861,
+      name: "skill.12304861.name",
+      mod: "",
+      description: "skill.12304861.description",
+      detailDescription: "skill.12304861.detailDescription",
+      ExSkillList: [],
+      cardID: 10600574,
+    },
+  },
+  breakthroughs: {},
+  talents: {},
+  images: {},
+  charSkillMap: {
+    "10001393": {
+      skills: [12304489, 12304490, 12304861],
+      relatedSkills: [12304492],
+      notFromCharacters: [],
+    },
+  },
+  itemSkillMap: {},
+}
+
+describe("Issue #109: 美琪 旧IDインポート時の推論復元", () => {
+  it("relatedSkillsに誤フォールバックせず、skillIndexから信号上書きを正しく復元する", async () => {
+    const { result } = renderHook(() => useDeckBuilder(mockData))
+
+    const presetFromDevice = {
+      roleList: [10001393, -1, -1, -1, -1],
+      header: 10001393,
+      cardList: [
+        { id: 10600574, ownerId: 10001393, skillId: 12304861, skillIndex: 3, useType: 1, useParam: -1, targetType: 0, equipIdList: [] },
+        { id: 10600575, ownerId: 10001393, skillId: 12304859, skillIndex: 2, useType: 1, useParam: -1, targetType: 0, equipIdList: [] },
+        { id: 10600572, ownerId: 10001393, skillId: 12304492, useType: 1, useParam: -1, targetType: 0, equipIdList: [] },
+        { id: 10600573, ownerId: 10001393, skillId: 12304489, skillIndex: 1, useType: 1, useParam: -1, targetType: 0, equipIdList: [] },
+      ],
+      isLeaderCardOn: true,
+      isSpCardOn: true,
+      keepCardNum: 0,
+      discardType: 1,
+      otherCard: 0,
+    }
+
+    act(() => {
+      const importResult = result.current.importPresetObject(presetFromDevice as never)
+      expect(importResult.success).toBe(true)
+    })
+
+    await waitFor(() => {
+      expect(result.current.selectedCards.length).toBeGreaterThan(0)
+    })
+
+    const meiqiCardIds = result.current.selectedCards
+      .map((card) => String(card.id))
+      .filter((id) => ["10600571", "10600572", "10600573", "10600574"].includes(id))
+
+    expect(meiqiCardIds).toEqual(["10600574", "10600571", "10600572", "10600573"])
+  })
+})


### PR DESCRIPTION
Legacy device presets can include old Meiqi card/skill IDs that are no longer present in the current master data. The previous fallback path could resolve these to unrelated cards via relatedSkills, which caused Signal Overwrite and Cooperative Shooting placement mismatches.

## What changed
- Reworked unavailable-card replacement in `importPresetObject` to use inference in a safer order:
  1. `ownerId + skillIndex` to map through current `character.skillList`
  2. direct `skillId -> cardID` resolution when valid
  3. skill name key matching (`skill.xxx.name`) with unique-candidate guard
  4. unique owner-related fallback only when `skillId/skillIndex` are absent
- Added ambiguity guards so uncertain matches are not force-replaced.
- Added a regression test for Issue #109 that reproduces legacy-ID input and verifies restored Meiqi card order.

## Notes for reviewers
- This keeps existing Issue #96/#100 behaviors while removing the broad relatedSkills-first fallback that caused misclassification.
- Matching now prefers deterministic metadata over translated text values.

Fixes: #109